### PR TITLE
feat: Phase 176 – Self-Healing Watchdog Auto-Restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,14 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Zusätzliche Pfade für den File-Agent (Doppelpunkt-getrennt)
 # FABBOT_EXTRA_PATHS=/Volumes/McAir SSD/fmorena/PythonProject
 KNOWLEDGE_DIR=""  # z.B. ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Wissen
+
+# ── Optional: Watchdog Auto-Restart ──────────────────────────────────────────
+
+# Auto-Restart aktivieren (true/false, Default: true)
+# WATCHDOG_AUTO_RESTART=true
+
+# Wartezeit nach Alert bevor erster Restart versucht wird (Minuten, Default: 5)
+# WATCHDOG_RESTART_DELAY_MIN=5
+
+# Maximale Restart-Versuche pro Down-Periode (Default: 3)
+# WATCHDOG_MAX_RESTARTS=3

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 173** ✅ _invoke_locks LRU-Eviction + Scheduler Liveness + Data Store Diagram – _invoke_locks as OrderedDict with LRU-Eviction (max 100 entries); Scheduler tasks named (scheduler:briefing etc.); _check_schedulers() as 13th health check component; data store table (6 stores) added to README; 1296 tests green
 - **Phase 174** ✅ ruff CI + codebase formatting – lint.yml with ruff check + ruff format --check; pyproject.toml with E402/E741 ignore rules; 130 auto-fixed violations + 17 manual fixes; entire codebase reformatted (91 files); 1296 tests green
 - **Phase 175** ✅ Supervisor routing pipeline refactor – supervisor_node() split into ordered _pre_route() strategy pipeline (image_data → AIMessage early-return → vision follow-up → pre-routing table → LLM); each strategy is its own function; _PRE_ROUTE_PIPELINE list makes order explicit; 1296 tests green
+- **Phase 176** ✅ Self-Healing Watchdog Auto-Restart – watchdog.py extended with _attempt_restart() via launchctl kickstart; configurable delay (WATCHDOG_RESTART_DELAY_MIN), max attempts (WATCHDOG_MAX_RESTARTS), feature flag (WATCHDOG_AUTO_RESTART); Telegram alerts on attempt/success/failure; state tracks restart_count + last_restart_at; 1310 tests green
 
 ---
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,11 +1,7 @@
 """Tests für watchdog.py Auto-Restart-Logik (Issue #105)."""
 
-import json
 from datetime import datetime, timedelta
-from pathlib import Path
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 
 def _make_state(**overrides) -> dict:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -141,7 +141,9 @@ class TestMainAutoRestart:
             patch("watchdog._save_state") as mock_save,
             patch("watchdog._is_launch_agent_running", return_value=bot_up),
             patch("watchdog._is_python_process_running", return_value=bot_up),
-            patch("watchdog._attempt_restart", return_value={**state, "restart_count": state.get("restart_count", 0) + 1}) as mock_restart,
+            patch(
+                "watchdog._attempt_restart", return_value={**state, "restart_count": state.get("restart_count", 0) + 1}
+            ) as mock_restart,
             patch("watchdog._send_telegram", return_value=True),
         ):
             wd.main()

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,222 @@
+"""Tests für watchdog.py Auto-Restart-Logik (Issue #105)."""
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+def _make_state(**overrides) -> dict:
+    base = {
+        "last_status": "down",
+        "down_since": (datetime.now() - timedelta(minutes=15)).isoformat(),
+        "notified": True,
+        "notified_at": (datetime.now() - timedelta(minutes=6)).isoformat(),
+        "restart_count": 0,
+        "last_restart_at": None,
+    }
+    return {**base, **overrides}
+
+
+# ---------------------------------------------------------------------------
+# _attempt_restart
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptRestart:
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up", return_value=True)
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run")
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_success_updates_state(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        mock_run.return_value = MagicMock(returncode=0)
+        from watchdog import _attempt_restart
+
+        state = _make_state(restart_count=0)
+        result = _attempt_restart(state)
+
+        assert result["last_status"] == "up"
+        assert result["restart_count"] == 1
+        assert result["notified"] is False
+        assert result["down_since"] is None
+        mock_sleep.assert_called_once_with(60)
+
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up", return_value=True)
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run")
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_success_sends_correct_telegram(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        mock_run.return_value = MagicMock(returncode=0)
+        from watchdog import _attempt_restart
+
+        _attempt_restart(_make_state(restart_count=0))
+
+        calls = [str(c) for c in mock_tg.call_args_list]
+        assert any("automatisch neu gestartet" in c for c in calls)
+
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up", return_value=False)
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run")
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_failure_bot_not_started(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        mock_run.return_value = MagicMock(returncode=0)
+        from watchdog import _attempt_restart
+
+        state = _make_state(restart_count=0)
+        result = _attempt_restart(state)
+
+        assert result["last_status"] == "down"
+        assert result["restart_count"] == 1
+        assert result["last_restart_at"] is not None
+        calls = [str(c) for c in mock_tg.call_args_list]
+        assert any("fehlgeschlagen" in c for c in calls)
+
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up", return_value=False)
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run")
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_kickstart_error_no_sleep(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        mock_run.return_value = MagicMock(returncode=1)
+        from watchdog import _attempt_restart
+
+        _attempt_restart(_make_state(restart_count=0))
+
+        mock_sleep.assert_not_called()
+
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up", return_value=False)
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run")
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_last_attempt_hints_manual_intervention(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        import watchdog as wd
+        from watchdog import _attempt_restart
+
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(wd, "WATCHDOG_MAX_RESTARTS", 3):
+            _attempt_restart(_make_state(restart_count=2))
+
+        calls = [str(c) for c in mock_tg.call_args_list]
+        assert any("manuell" in c for c in calls)
+
+    @patch("watchdog.time.sleep")
+    @patch("watchdog._is_bot_up")
+    @patch("watchdog._send_telegram", return_value=True)
+    @patch("watchdog.subprocess.run", side_effect=Exception("timeout"))
+    @patch("watchdog.os.getuid", return_value=501)
+    def test_subprocess_exception_handled(self, mock_uid, mock_run, mock_tg, mock_up, mock_sleep):
+        mock_up.return_value = False
+        from watchdog import _attempt_restart
+
+        result = _attempt_restart(_make_state(restart_count=0))
+
+        assert result["restart_count"] == 1
+        assert result["last_status"] == "down"
+
+
+# ---------------------------------------------------------------------------
+# main() – Integration
+# ---------------------------------------------------------------------------
+
+
+class TestMainAutoRestart:
+    def _run_main(self, state: dict, bot_up: bool, env_overrides: dict | None = None):
+        import watchdog as wd
+
+        env = {
+            "WATCHDOG_AUTO_RESTART": "true",
+            "WATCHDOG_RESTART_DELAY_MIN": "5",
+            "WATCHDOG_MAX_RESTARTS": "3",
+            **(env_overrides or {}),
+        }
+        with (
+            patch.object(wd, "BOT_TOKEN", "fake-token"),
+            patch.object(wd, "CHAT_ID", "123"),
+            patch.object(wd, "WATCHDOG_AUTO_RESTART", env["WATCHDOG_AUTO_RESTART"] == "true"),
+            patch.object(wd, "WATCHDOG_RESTART_DELAY_MIN", int(env["WATCHDOG_RESTART_DELAY_MIN"])),
+            patch.object(wd, "WATCHDOG_MAX_RESTARTS", int(env["WATCHDOG_MAX_RESTARTS"])),
+            patch("watchdog._load_state", return_value=state),
+            patch("watchdog._save_state") as mock_save,
+            patch("watchdog._is_launch_agent_running", return_value=bot_up),
+            patch("watchdog._is_python_process_running", return_value=bot_up),
+            patch("watchdog._attempt_restart", return_value={**state, "restart_count": state.get("restart_count", 0) + 1}) as mock_restart,
+            patch("watchdog._send_telegram", return_value=True),
+        ):
+            wd.main()
+            return mock_save.call_args[0][0], mock_restart
+
+    def test_restart_triggered_after_delay(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=6)).isoformat(),
+            restart_count=0,
+        )
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_called_once()
+
+    def test_restart_not_triggered_before_delay(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=2)).isoformat(),
+            restart_count=0,
+        )
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_not_called()
+
+    def test_restart_not_triggered_when_max_reached(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=10)).isoformat(),
+            restart_count=3,
+        )
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_not_called()
+
+    def test_restart_disabled_via_feature_flag(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=10)).isoformat(),
+            restart_count=0,
+        )
+        saved_state, mock_restart = self._run_main(
+            state, bot_up=False, env_overrides={"WATCHDOG_AUTO_RESTART": "false"}
+        )
+        mock_restart.assert_not_called()
+
+    def test_recovery_resets_restart_fields(self):
+        state = _make_state(
+            last_status="down",
+            notified=True,
+            restart_count=2,
+            last_restart_at=(datetime.now() - timedelta(minutes=1)).isoformat(),
+        )
+        saved_state, _ = self._run_main(state, bot_up=True)
+
+        assert saved_state["restart_count"] == 0
+        assert saved_state["last_restart_at"] is None
+        assert saved_state["notified"] is False
+
+    def test_not_notified_no_restart(self):
+        state = _make_state(notified=False, notified_at=None, restart_count=0)
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_not_called()
+
+    def test_uses_last_restart_at_as_reference_for_second_attempt(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=30)).isoformat(),
+            restart_count=1,
+            last_restart_at=(datetime.now() - timedelta(minutes=6)).isoformat(),
+        )
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_called_once()
+
+    def test_second_attempt_too_soon_skipped(self):
+        state = _make_state(
+            notified_at=(datetime.now() - timedelta(minutes=30)).isoformat(),
+            restart_count=1,
+            last_restart_at=(datetime.now() - timedelta(minutes=2)).isoformat(),
+        )
+        saved_state, mock_restart = self._run_main(state, bot_up=False)
+        mock_restart.assert_not_called()

--- a/watchdog.py
+++ b/watchdog.py
@@ -211,9 +211,7 @@ def _attempt_restart(state: dict) -> dict:
         final = restart_num >= WATCHDOG_MAX_RESTARTS
         suffix = "Bitte manuell eingreifen!" if final else "Nächster Versuch beim nächsten Check."
         print(f"{LOG_PREFIX} Auto-Restart #{restart_num} fehlgeschlagen ❌")
-        _send_telegram(
-            f"🚨 *Auto-Restart #{restart_num} fehlgeschlagen* – {reason}\n{suffix}"
-        )
+        _send_telegram(f"🚨 *Auto-Restart #{restart_num} fehlgeschlagen* – {reason}\n{suffix}")
 
     return state
 

--- a/watchdog.py
+++ b/watchdog.py
@@ -8,6 +8,7 @@ Prüft:
 
 Bei Problem: Telegram-Nachricht direkt via HTTP (kein Bot-Framework nötig).
 Bei Recovery: Entwarnung senden.
+Auto-Restart: Nach konfigurierbarer Wartezeit wird launchctl kickstart versucht.
 
 State wird in ~/.fabbot/watchdog_state.json gespeichert –
 verhindert Spam-Nachrichten bei dauerhaftem Ausfall.
@@ -20,6 +21,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -73,8 +75,11 @@ STATE_PATH = Path.home() / ".fabbot" / "watchdog_state.json"
 LOG_PREFIX = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Watchdog:"
 
 # Phase 86 Fix #6: Benannte Konstante statt Magic Number.
-# Vorher: `if mins_down >= 9:  # nach ~10 Minuten` – Kommentar und Code widersprüchlich.
 _ALERT_DELAY_MINUTES = 10
+
+WATCHDOG_AUTO_RESTART = os.getenv("WATCHDOG_AUTO_RESTART", "true").lower() == "true"
+WATCHDOG_RESTART_DELAY_MIN = int(os.getenv("WATCHDOG_RESTART_DELAY_MIN", "5"))
+WATCHDOG_MAX_RESTARTS = int(os.getenv("WATCHDOG_MAX_RESTARTS", "3"))
 
 # ---------------------------------------------------------------------------
 # State Management
@@ -82,12 +87,21 @@ _ALERT_DELAY_MINUTES = 10
 
 
 def _load_state() -> dict:
+    defaults = {
+        "last_status": "unknown",
+        "down_since": None,
+        "notified": False,
+        "notified_at": None,
+        "restart_count": 0,
+        "last_restart_at": None,
+    }
     try:
         if STATE_PATH.exists():
-            return json.loads(STATE_PATH.read_text())
+            stored = json.loads(STATE_PATH.read_text())
+            return {**defaults, **stored}
     except Exception as e:
         print(f"{LOG_PREFIX} State laden fehlgeschlagen: {e}")
-    return {"last_status": "unknown", "down_since": None, "notified": False}
+    return defaults
 
 
 def _save_state(state: dict) -> None:
@@ -150,6 +164,61 @@ def _send_telegram(message: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Auto-Restart
+# ---------------------------------------------------------------------------
+
+
+def _attempt_restart(state: dict) -> dict:
+    """Versucht Bot-Neustart via launchctl kickstart. Gibt aktualisierten State zurück."""
+    restart_num = state.get("restart_count", 0) + 1
+    uid = os.getuid()
+    service = f"gui/{uid}/com.fabbot.agent"
+
+    print(f"{LOG_PREFIX} Auto-Restart #{restart_num} via launchctl kickstart...")
+    _send_telegram(f"🔄 *FabBot Auto-Restart #{restart_num}* wird versucht...")
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "kickstart", "-k", service],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        kickstart_ok = result.returncode == 0
+    except Exception as e:
+        print(f"{LOG_PREFIX} launchctl kickstart Fehler: {e}")
+        kickstart_ok = False
+
+    state["restart_count"] = restart_num
+    state["last_restart_at"] = datetime.now().isoformat()
+
+    if kickstart_ok:
+        print(f"{LOG_PREFIX} Warte 60s auf Bot-Start...")
+        time.sleep(60)
+        bot_up_now = _is_bot_up()
+    else:
+        bot_up_now = False
+
+    if bot_up_now:
+        print(f"{LOG_PREFIX} Auto-Restart erfolgreich ✅")
+        _send_telegram(f"✅ *FabBot automatisch neu gestartet* (Versuch #{restart_num})")
+        state["last_status"] = "up"
+        state["down_since"] = None
+        state["notified"] = False
+        state["notified_at"] = None
+    else:
+        reason = "launchctl Fehler" if not kickstart_ok else "Bot startet nicht"
+        final = restart_num >= WATCHDOG_MAX_RESTARTS
+        suffix = "Bitte manuell eingreifen!" if final else "Nächster Versuch beim nächsten Check."
+        print(f"{LOG_PREFIX} Auto-Restart #{restart_num} fehlgeschlagen ❌")
+        _send_telegram(
+            f"🚨 *Auto-Restart #{restart_num} fehlgeschlagen* – {reason}\n{suffix}"
+        )
+
+    return state
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -164,7 +233,6 @@ def main() -> None:
     if bot_up:
         print(f"{LOG_PREFIX} Bot läuft ✅")
         if state.get("last_status") == "down" and state.get("notified"):
-            # Recovery – Entwarnung senden
             downtime = ""
             if state.get("down_since"):
                 try:
@@ -178,6 +246,9 @@ def main() -> None:
         state["last_status"] = "up"
         state["down_since"] = None
         state["notified"] = False
+        state["notified_at"] = None
+        state["restart_count"] = 0
+        state["last_restart_at"] = None
     else:
         print(f"{LOG_PREFIX} Bot DOWN ❌")
         if state.get("last_status") != "down":
@@ -202,7 +273,21 @@ def main() -> None:
                 )
                 if sent:
                     state["notified"] = True
+                    state["notified_at"] = now
                     print(f"{LOG_PREFIX} Alert gesendet.")
+
+        if state.get("notified") and WATCHDOG_AUTO_RESTART:
+            restart_count = state.get("restart_count", 0)
+            if restart_count < WATCHDOG_MAX_RESTARTS:
+                reference = state.get("last_restart_at") or state.get("notified_at")
+                if reference:
+                    try:
+                        ref_dt = datetime.fromisoformat(reference)
+                        mins_elapsed = (datetime.now() - ref_dt).total_seconds() / 60
+                    except Exception:
+                        mins_elapsed = WATCHDOG_RESTART_DELAY_MIN
+                    if mins_elapsed >= WATCHDOG_RESTART_DELAY_MIN:
+                        state = _attempt_restart(state)
 
     _save_state(state)
 


### PR DESCRIPTION
## Änderungen

- `watchdog.py`: `_attempt_restart()` via `launchctl kickstart -k` mit 60s Wartezeit + Re-Check
- Konfigurierbarer Delay vor erstem Restart (`WATCHDOG_RESTART_DELAY_MIN`, default: 5 min)
- Max. Restart-Versuche pro Down-Periode (`WATCHDOG_MAX_RESTARTS`, default: 3)
- Feature-Flag (`WATCHDOG_AUTO_RESTART=false` deaktiviert alles)
- Telegram-Alerts bei Versuch, Erfolg und Misserfolg
- State erweitert um `restart_count`, `notified_at`, `last_restart_at`
- `.env.example`: neue Variablen dokumentiert
- `tests/test_watchdog.py`: 14 neue Tests (subprocess-mock)

## Tests

1310 passed, 0 failures

Closes #105