### PR TITLE
feat: Phase 177 – Fix Memory-Reviewer Truncation-Bug bei großem Profil

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 174** ✅ ruff CI + codebase formatting – lint.yml with ruff check + ruff format --check; pyproject.toml with E402/E741 ignore rules; 130 auto-fixed violations + 17 manual fixes; entire codebase reformatted (91 files); 1296 tests green
 - **Phase 175** ✅ Supervisor routing pipeline refactor – supervisor_node() split into ordered _pre_route() strategy pipeline (image_data → AIMessage early-return → vision follow-up → pre-routing table → LLM); each strategy is its own function; _PRE_ROUTE_PIPELINE list makes order explicit; 1296 tests green
 - **Phase 176** ✅ Self-Healing Watchdog Auto-Restart – watchdog.py extended with _attempt_restart() via launchctl kickstart; configurable delay (WATCHDOG_RESTART_DELAY_MIN), max attempts (WATCHDOG_MAX_RESTARTS), feature flag (WATCHDOG_AUTO_RESTART); Telegram alerts on attempt/success/failure; state tracks restart_count + last_restart_at; 1310 tests green
+- **Phase 177** ✅ Fix Memory-Reviewer Truncation-Bug – _review_yaml used LLM with 2000-char truncation; profile grown to 6300 chars so new entries (people etc.) were invisible to reviewer → always INVALID; replaced LLM call for save/update with structural _is_valid_save() superset-check (same pattern as _is_valid_delete); 1310 tests green
 
 ---
 

--- a/agent/agents/memory_agent.py
+++ b/agent/agents/memory_agent.py
@@ -492,10 +492,45 @@ def _is_valid_delete(original: dict, updated: dict) -> bool:
         return False
 
 
+def _is_valid_save(original: dict, updated: dict) -> bool:
+    """Superset-Prüfung für save/update: alle Daten aus original müssen in updated erhalten sein."""
+    try:
+        original_str = yaml.dump(original, allow_unicode=True, sort_keys=True)
+        updated_str = yaml.dump(updated, allow_unicode=True, sort_keys=True)
+
+        if original_str == updated_str:
+            return True
+
+        def is_superset(new: Any, orig: Any) -> bool:
+            if isinstance(new, dict) and isinstance(orig, dict):
+                for k, v in orig.items():
+                    if k not in new:
+                        return False
+                    if not is_superset(new[k], v):
+                        return False
+                return True
+            elif isinstance(new, list) and isinstance(orig, list):
+                for item in orig:
+                    if item not in new:
+                        return False
+                return True
+            else:
+                return new == orig
+
+        result = is_superset(updated, original)
+        if not result:
+            logger.warning("MemoryAgent _is_valid_save: Daten verloren – kein valider Save")
+        return result
+
+    except Exception as e:
+        logger.error(f"MemoryAgent _is_valid_save: Fehler bei Superset-Prüfung: {e}")
+        return False
+
+
 async def _review_yaml(original_yaml: str, new_yaml: str, action: str = "save") -> bool:
     """
     Phase 115: Bei delete → strukturelle Subset-Vorprüfung ohne LLM-Call.
-    Bei save/update → LLM-Reviewer wie bisher.
+    Phase 177: Bei save/update → strukturelle Superset-Prüfung (LLM-Truncation-Bug-Fix).
     """
     try:
         if action == "delete":
@@ -514,21 +549,22 @@ async def _review_yaml(original_yaml: str, new_yaml: str, action: str = "save") 
             logger.info(f"MemoryAgent _review_yaml delete: strukturelle Prüfung → {'VALID' if result else 'INVALID'}")
             return result
 
-        llm = get_fast_llm()
-        prompt = _REVIEWER_PROMPT.format(
-            action=action,
-            original=original_yaml[:2000],
-            new=new_yaml[:2000],
-        )
-        response = await llm.ainvoke([HumanMessage(content=prompt)])
-        content = response.content
-        if isinstance(content, list):
-            content = " ".join(b.get("text", "") if isinstance(b, dict) else str(b) for b in content)
-        verdict = content.strip().upper()
-        is_valid = verdict == "VALID"
-        if not is_valid:
-            logger.warning(f"MemoryAgent Reviewer: INVALID – verdict='{verdict}'")
-        return is_valid
+        if action in ("save", "update"):
+            try:
+                original_dict = yaml.safe_load(original_yaml)
+                updated_dict = yaml.safe_load(new_yaml)
+            except yaml.YAMLError as e:
+                logger.error(f"MemoryAgent _review_yaml save: YAML-Parse-Fehler: {e}")
+                return False
+            if not isinstance(original_dict, dict) or not isinstance(updated_dict, dict):
+                logger.error("MemoryAgent _review_yaml save: kein dict nach YAML-Parse")
+                return False
+            result = _is_valid_save(original_dict, updated_dict)
+            logger.info(f"MemoryAgent _review_yaml save: strukturelle Prüfung → {'VALID' if result else 'INVALID'}")
+            return result
+
+        logger.warning(f"MemoryAgent _review_yaml: unbekannte action='{action}' → VALID")
+        return True
 
     except Exception as e:
         logger.error(f"MemoryAgent Reviewer Fehler: {e}")


### PR DESCRIPTION
## Änderungen
- `_review_yaml()` nutzte LLM mit 2000-Zeichen-Truncation für save/update-Validierung
- Profil auf 6300 Zeichen gewachsen → neue Einträge außerhalb des Fensters
- Reviewer sah beide YAMLs als identisch → immer INVALID → Personen konnten nicht gespeichert werden
- Fix: neue `_is_valid_save()` mit struktureller Superset-Prüfung (analog zu `_is_valid_delete`)
- LLM-Call für save/update komplett entfernt – schneller, deterministisch, skaliert mit Profilgröße

## Tests
1310 passed, 0 failures