### PR TITLE
fix: curator dryrun zeigt konkreten Fehlergrund

### DIFF
--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -379,16 +379,22 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     Gibt Report-String zurück oder None bei leerem Profil / LLM-Fehler.
     force=True ignoriert Idle-Check (für manuellen /curator dryrun).
     """
+    report, _ = await _debug_dry_run(force=force)
+    return report
+
+
+async def _debug_dry_run(*, force: bool = False) -> tuple[str | None, str]:
+    """Wie run_dry_run, gibt zusätzlich Debug-Info zurück: (report, debug_msg)."""
     from agent.profile import load_profile_with_hash
 
     profile, base_hash = load_profile_with_hash()
     if not profile:
         logger.info("curator run_dry_run: Profil leer – übersprungen.")
-        return None
+        return None, "Profil ist leer oder konnte nicht geladen werden."
 
     analysis = await _analyze_profile(profile)
     if analysis is None:
-        return None
+        return None, "LLM-Analyse fehlgeschlagen (Timeout, Auth oder JSON-Fehler – siehe Log)."
 
     proposal = _build_proposal(profile, analysis)
     expires_at = (datetime.now(timezone.utc) + timedelta(seconds=_PROPOSAL_TTL)).isoformat()
@@ -401,7 +407,7 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     _save_state(state)
 
     logger.info(f"curator Dry-Run abgeschlossen: {len(proposal['operations'])} Operationen vorgeschlagen.")
-    return format_report(proposal, expires_at)
+    return format_report(proposal, expires_at), "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -707,13 +707,13 @@ async def cmd_curator(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
     if sub == "dryrun":
         thinking = await update.message.reply_text("Analysiere Profil...")
-        from agent.proactive.curator import run_dry_run
+        from agent.proactive.curator import _debug_dry_run
 
-        report = await run_dry_run(force=True)
+        report, debug_info = await _debug_dry_run(force=True)
         if report:
             await thinking.edit_text(report, parse_mode="Markdown")
         else:
-            await thinking.edit_text("Profil leer oder Analyse fehlgeschlagen.")
+            await thinking.edit_text(f"Fehlgeschlagen: {debug_info}")
 
     elif sub == "apply":
         thinking = await update.message.reply_text("Wende Vorschlag an...")


### PR DESCRIPTION
Unterscheidet jetzt zwischen leerem Profil und LLM-Fehler in der Bot-Antwort.