### PR TITLE
fix: curator _safe_int für alle Index-Konvertierungen

### DIFF
--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -379,16 +379,22 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     Gibt Report-String zurück oder None bei leerem Profil / LLM-Fehler.
     force=True ignoriert Idle-Check (für manuellen /curator dryrun).
     """
+    report, _ = await _debug_dry_run(force=force)
+    return report
+
+
+async def _debug_dry_run(*, force: bool = False) -> tuple[str | None, str]:
+    """Wie run_dry_run, gibt zusätzlich Debug-Info zurück: (report, debug_msg)."""
     from agent.profile import load_profile_with_hash
 
     profile, base_hash = load_profile_with_hash()
     if not profile:
         logger.info("curator run_dry_run: Profil leer – übersprungen.")
-        return None
+        return None, "Profil ist leer oder konnte nicht geladen werden."
 
     analysis = await _analyze_profile(profile)
     if analysis is None:
-        return None
+        return None, "LLM-Analyse fehlgeschlagen (Timeout, Auth oder JSON-Fehler – siehe Log)."
 
     proposal = _build_proposal(profile, analysis)
     expires_at = (datetime.now(timezone.utc) + timedelta(seconds=_PROPOSAL_TTL)).isoformat()
@@ -401,7 +407,7 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     _save_state(state)
 
     logger.info(f"curator Dry-Run abgeschlossen: {len(proposal['operations'])} Operationen vorgeschlagen.")
-    return format_report(proposal, expires_at)
+    return format_report(proposal, expires_at), "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -31,7 +31,7 @@ _FABBOT_LOG = Path.home() / ".fabbot" / "fabbot.log"
 _IDLE_THRESHOLD = 2 * 3600  # 2 Stunden
 _COOLDOWN_DAYS = 7  # Mindesttakt zwischen Läufen
 _PROPOSAL_TTL = 24 * 3600  # Proposal verfällt nach 24h
-_LLM_TIMEOUT = 30.0
+_LLM_TIMEOUT = 60.0
 
 
 # ---------------------------------------------------------------------------

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -233,9 +233,13 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Veraltete Einträge archivieren
     for stale in analysis.get("stale", []):
         section = stale.get("section", "")
-        idx = stale.get("index")
+        idx_raw = stale.get("index")
         reason = stale.get("reason", "veraltet")
-        if idx is None or not section:
+        if idx_raw is None or not section:
+            continue
+        try:
+            idx = int(idx_raw)
+        except (ValueError, TypeError):
             continue
 
         # Navigation durch verschachtelte Sektionen (z.B. "projects.active")
@@ -263,9 +267,12 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Redundante Notes
     notes = target.get("notes", [])
     if isinstance(notes, list):
-        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index") or 0, reverse=True):
-            indices = rn.get("indices", [])
-            keep_index = rn.get("keep_index", indices[0] if indices else None)
+        for rn in sorted(
+            analysis.get("redundant_notes", []), key=lambda x: int(x.get("keep_index") or 0), reverse=True
+        ):
+            indices = [int(i) for i in rn.get("indices", []) if i is not None]
+            keep_index_raw = rn.get("keep_index", indices[0] if indices else None)
+            keep_index = int(keep_index_raw) if keep_index_raw is not None else None
             reason = rn.get("reason", "redundant")
             for idx in sorted(indices, reverse=True):
                 if idx == keep_index or idx >= len(notes):
@@ -280,8 +287,10 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Duplikate: keep_index behalten, andere archivieren + optional mergen
     for dup in analysis.get("duplicates", []):
         section = dup.get("section", "")
-        indices = dup.get("indices", [])
-        keep_index = dup.get("keep_index", indices[0] if indices else None)
+        raw_indices = dup.get("indices", [])
+        indices = [int(i) for i in raw_indices if i is not None]
+        keep_index_raw = dup.get("keep_index", indices[0] if indices else None)
+        keep_index = int(keep_index_raw) if keep_index_raw is not None else None
         merged_entry = dup.get("merged_entry")
         reason = dup.get("reason", "Duplikat")
         if not section or not indices:

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -126,6 +126,13 @@ def _get_pinned_paths(profile: dict) -> set[str]:
     return set(_filter_pinned(profile))
 
 
+def _safe_int(val: Any, default: int = 0) -> int:
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
 # ---------------------------------------------------------------------------
 # LLM-Analyse
 # ---------------------------------------------------------------------------
@@ -268,11 +275,12 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     notes = target.get("notes", [])
     if isinstance(notes, list):
         for rn in sorted(
-            analysis.get("redundant_notes", []), key=lambda x: int(x.get("keep_index") or 0), reverse=True
+            analysis.get("redundant_notes", []), key=lambda x: _safe_int(x.get("keep_index")), reverse=True
         ):
-            indices = [int(i) for i in rn.get("indices", []) if i is not None]
+            indices = [_safe_int(i, -1) for i in rn.get("indices", []) if i is not None]
+            indices = [i for i in indices if i >= 0]
             keep_index_raw = rn.get("keep_index", indices[0] if indices else None)
-            keep_index = int(keep_index_raw) if keep_index_raw is not None else None
+            keep_index = _safe_int(keep_index_raw, -1) if keep_index_raw is not None else None
             reason = rn.get("reason", "redundant")
             for idx in sorted(indices, reverse=True):
                 if idx == keep_index or idx >= len(notes):
@@ -290,7 +298,7 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
         raw_indices = dup.get("indices", [])
         indices = [int(i) for i in raw_indices if i is not None]
         keep_index_raw = dup.get("keep_index", indices[0] if indices else None)
-        keep_index = int(keep_index_raw) if keep_index_raw is not None else None
+        keep_index = _safe_int(keep_index_raw, -1) if keep_index_raw is not None else None
         merged_entry = dup.get("merged_entry")
         reason = dup.get("reason", "Duplikat")
         if not section or not indices:

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -251,8 +251,9 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
             if isinstance(item, dict) and item.get("_pinned"):
                 logger.warning(f"curator: _pinned-Item in stale ignoriert: {section}[{idx}]")
                 continue
+            base = item if isinstance(item, dict) else {"_value": item}
             archived_list.append(
-                {**item, "_archived_at": now_iso, "_archived_reason": reason, "_archived_from": section}
+                {**base, "_archived_at": now_iso, "_archived_reason": reason, "_archived_from": section}
             )
             obj.pop(idx)
             operations.append({"type": "archive", "section": section, "index": idx, "reason": reason})
@@ -262,7 +263,7 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Redundante Notes
     notes = target.get("notes", [])
     if isinstance(notes, list):
-        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index", 0), reverse=True):
+        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index") or 0, reverse=True):
             indices = rn.get("indices", [])
             keep_index = rn.get("keep_index", indices[0] if indices else None)
             reason = rn.get("reason", "redundant")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -707,13 +707,13 @@ async def cmd_curator(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
     if sub == "dryrun":
         thinking = await update.message.reply_text("Analysiere Profil...")
-        from agent.proactive.curator import run_dry_run
+        from agent.proactive.curator import _debug_dry_run
 
-        report = await run_dry_run(force=True)
+        report, debug_info = await _debug_dry_run(force=True)
         if report:
             await thinking.edit_text(report, parse_mode="Markdown")
         else:
-            await thinking.edit_text("Profil leer oder Analyse fehlgeschlagen.")
+            await thinking.edit_text(f"Fehlgeschlagen: {debug_info}")
 
     elif sub == "apply":
         thinking = await update.message.reply_text("Wende Vorschlag an...")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -711,7 +711,10 @@ async def cmd_curator(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
         report, debug_info = await _debug_dry_run(force=True)
         if report:
-            await thinking.edit_text(report, parse_mode="Markdown")
+            try:
+                await thinking.edit_text(report, parse_mode="Markdown")
+            except Exception:
+                await thinking.edit_text(report)
         else:
             await thinking.edit_text(f"Fehlgeschlagen: {debug_info}")
 


### PR DESCRIPTION
LLM gibt keep_index manchmal als String wie 'note[19.04.2026 13:53]' zurück. _safe_int() fängt alle ValueError/TypeError ab.