### PR TITLE
fix: curator Prompt + _sanitize_analysis gegen LLM-Halluzination

### DIFF
--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -379,16 +379,22 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     Gibt Report-String zurück oder None bei leerem Profil / LLM-Fehler.
     force=True ignoriert Idle-Check (für manuellen /curator dryrun).
     """
+    report, _ = await _debug_dry_run(force=force)
+    return report
+
+
+async def _debug_dry_run(*, force: bool = False) -> tuple[str | None, str]:
+    """Wie run_dry_run, gibt zusätzlich Debug-Info zurück: (report, debug_msg)."""
     from agent.profile import load_profile_with_hash
 
     profile, base_hash = load_profile_with_hash()
     if not profile:
         logger.info("curator run_dry_run: Profil leer – übersprungen.")
-        return None
+        return None, "Profil ist leer oder konnte nicht geladen werden."
 
     analysis = await _analyze_profile(profile)
     if analysis is None:
-        return None
+        return None, "LLM-Analyse fehlgeschlagen (Timeout, Auth oder JSON-Fehler – siehe Log)."
 
     proposal = _build_proposal(profile, analysis)
     expires_at = (datetime.now(timezone.utc) + timedelta(seconds=_PROPOSAL_TTL)).isoformat()
@@ -401,7 +407,7 @@ async def run_dry_run(*, force: bool = False) -> str | None:
     _save_state(state)
 
     logger.info(f"curator Dry-Run abgeschlossen: {len(proposal['operations'])} Operationen vorgeschlagen.")
-    return format_report(proposal, expires_at)
+    return format_report(proposal, expires_at), "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -145,9 +145,11 @@ Identifiziere:
 3. Redundante Notizen (mehrere Notes die dasselbe aussagen)
 4. Merge-Vorschläge (zwei Einträge die sinnvoll zusammengeführt werden könnten)
 
-WICHTIG:
+KRITISCHE REGELN – Verstöße machen die Ausgabe ungültig:
+- index, indices und keep_index sind IMMER ganzzahlige Integer (0, 1, 2, ...) – niemals Strings, Schlüssel oder Bezeichnungen
+- section ist IMMER ein einfacher Schlüssel oder Pfad wie "notes", "people", "projects.active" – niemals mit Leerzeichen oder "+"
 - Schlage NUR echte Probleme vor – lieber zu wenig als zu viel
-- Einträge mit _pinned: true NIEMALS anfassen (sie sind bereits ausgefiltert, trotzdem zur Sicherheit ignorieren)
+- Einträge mit _pinned: true NIEMALS anfassen
 - Archivieren statt löschen
 - Antworte NUR mit validem JSON, kein Text davor/danach
 
@@ -203,7 +205,7 @@ async def _analyze_profile(profile: dict) -> dict | None:
                 content = content[start:end]
 
         analysis = json.loads(content)
-        return analysis
+        return _sanitize_analysis(analysis)
     except json.JSONDecodeError as e:
         logger.warning(f"curator _analyze_profile: LLM-Antwort ist kein valides JSON: {e}")
         return None
@@ -213,6 +215,44 @@ async def _analyze_profile(profile: dict) -> dict | None:
     except Exception as e:
         logger.warning(f"curator _analyze_profile Fehler: {e}")
         return None
+
+
+def _sanitize_analysis(analysis: dict) -> dict:
+    """Filtert LLM-Ausgabe: entfernt Einträge mit ungültigen Indizes (Strings, None, negativ)."""
+
+    def valid_idx(v) -> bool:
+        try:
+            return int(v) >= 0
+        except (ValueError, TypeError):
+            return False
+
+    def valid_section(s) -> bool:
+        return isinstance(s, str) and " " not in s and "+" not in s and len(s) > 0
+
+    stale = [e for e in analysis.get("stale", []) if valid_section(e.get("section", "")) and valid_idx(e.get("index"))]
+    duplicates = [
+        e
+        for e in analysis.get("duplicates", [])
+        if valid_section(e.get("section", ""))
+        and all(valid_idx(i) for i in e.get("indices", []))
+        and valid_idx(e.get("keep_index", 0))
+    ]
+    redundant_notes = [
+        e for e in analysis.get("redundant_notes", []) if all(valid_idx(i) for i in e.get("indices", []))
+    ]
+
+    dropped = (
+        len(analysis.get("stale", []))
+        - len(stale)
+        + len(analysis.get("duplicates", []))
+        - len(duplicates)
+        + len(analysis.get("redundant_notes", []))
+        - len(redundant_notes)
+    )
+    if dropped:
+        logger.warning(f"curator _sanitize_analysis: {dropped} ungültige LLM-Einträge herausgefiltert.")
+
+    return {**analysis, "stale": stale, "duplicates": duplicates, "redundant_notes": redundant_notes}
 
 
 # ---------------------------------------------------------------------------

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -31,7 +31,7 @@ _FABBOT_LOG = Path.home() / ".fabbot" / "fabbot.log"
 _IDLE_THRESHOLD = 2 * 3600  # 2 Stunden
 _COOLDOWN_DAYS = 7  # Mindesttakt zwischen Läufen
 _PROPOSAL_TTL = 24 * 3600  # Proposal verfällt nach 24h
-_LLM_TIMEOUT = 30.0
+_LLM_TIMEOUT = 60.0
 
 
 # ---------------------------------------------------------------------------

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -233,9 +233,13 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Veraltete Einträge archivieren
     for stale in analysis.get("stale", []):
         section = stale.get("section", "")
-        idx = stale.get("index")
+        idx_raw = stale.get("index")
         reason = stale.get("reason", "veraltet")
-        if idx is None or not section:
+        if idx_raw is None or not section:
+            continue
+        try:
+            idx = int(idx_raw)
+        except (ValueError, TypeError):
             continue
 
         # Navigation durch verschachtelte Sektionen (z.B. "projects.active")
@@ -263,9 +267,12 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Redundante Notes
     notes = target.get("notes", [])
     if isinstance(notes, list):
-        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index") or 0, reverse=True):
-            indices = rn.get("indices", [])
-            keep_index = rn.get("keep_index", indices[0] if indices else None)
+        for rn in sorted(
+            analysis.get("redundant_notes", []), key=lambda x: int(x.get("keep_index") or 0), reverse=True
+        ):
+            indices = [int(i) for i in rn.get("indices", []) if i is not None]
+            keep_index_raw = rn.get("keep_index", indices[0] if indices else None)
+            keep_index = int(keep_index_raw) if keep_index_raw is not None else None
             reason = rn.get("reason", "redundant")
             for idx in sorted(indices, reverse=True):
                 if idx == keep_index or idx >= len(notes):
@@ -280,8 +287,10 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Duplikate: keep_index behalten, andere archivieren + optional mergen
     for dup in analysis.get("duplicates", []):
         section = dup.get("section", "")
-        indices = dup.get("indices", [])
-        keep_index = dup.get("keep_index", indices[0] if indices else None)
+        raw_indices = dup.get("indices", [])
+        indices = [int(i) for i in raw_indices if i is not None]
+        keep_index_raw = dup.get("keep_index", indices[0] if indices else None)
+        keep_index = int(keep_index_raw) if keep_index_raw is not None else None
         merged_entry = dup.get("merged_entry")
         reason = dup.get("reason", "Duplikat")
         if not section or not indices:

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -126,6 +126,13 @@ def _get_pinned_paths(profile: dict) -> set[str]:
     return set(_filter_pinned(profile))
 
 
+def _safe_int(val: Any, default: int = 0) -> int:
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
 # ---------------------------------------------------------------------------
 # LLM-Analyse
 # ---------------------------------------------------------------------------
@@ -268,11 +275,12 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     notes = target.get("notes", [])
     if isinstance(notes, list):
         for rn in sorted(
-            analysis.get("redundant_notes", []), key=lambda x: int(x.get("keep_index") or 0), reverse=True
+            analysis.get("redundant_notes", []), key=lambda x: _safe_int(x.get("keep_index")), reverse=True
         ):
-            indices = [int(i) for i in rn.get("indices", []) if i is not None]
+            indices = [_safe_int(i, -1) for i in rn.get("indices", []) if i is not None]
+            indices = [i for i in indices if i >= 0]
             keep_index_raw = rn.get("keep_index", indices[0] if indices else None)
-            keep_index = int(keep_index_raw) if keep_index_raw is not None else None
+            keep_index = _safe_int(keep_index_raw, -1) if keep_index_raw is not None else None
             reason = rn.get("reason", "redundant")
             for idx in sorted(indices, reverse=True):
                 if idx == keep_index or idx >= len(notes):
@@ -290,7 +298,7 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
         raw_indices = dup.get("indices", [])
         indices = [int(i) for i in raw_indices if i is not None]
         keep_index_raw = dup.get("keep_index", indices[0] if indices else None)
-        keep_index = int(keep_index_raw) if keep_index_raw is not None else None
+        keep_index = _safe_int(keep_index_raw, -1) if keep_index_raw is not None else None
         merged_entry = dup.get("merged_entry")
         reason = dup.get("reason", "Duplikat")
         if not section or not indices:

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -296,7 +296,8 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     for dup in analysis.get("duplicates", []):
         section = dup.get("section", "")
         raw_indices = dup.get("indices", [])
-        indices = [int(i) for i in raw_indices if i is not None]
+        indices = [_safe_int(i, -1) for i in raw_indices if i is not None]
+        indices = [i for i in indices if i >= 0]
         keep_index_raw = dup.get("keep_index", indices[0] if indices else None)
         keep_index = _safe_int(keep_index_raw, -1) if keep_index_raw is not None else None
         merged_entry = dup.get("merged_entry")

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -251,8 +251,9 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
             if isinstance(item, dict) and item.get("_pinned"):
                 logger.warning(f"curator: _pinned-Item in stale ignoriert: {section}[{idx}]")
                 continue
+            base = item if isinstance(item, dict) else {"_value": item}
             archived_list.append(
-                {**item, "_archived_at": now_iso, "_archived_reason": reason, "_archived_from": section}
+                {**base, "_archived_at": now_iso, "_archived_reason": reason, "_archived_from": section}
             )
             obj.pop(idx)
             operations.append({"type": "archive", "section": section, "index": idx, "reason": reason})
@@ -262,7 +263,7 @@ def _build_proposal(profile: dict, analysis: dict) -> dict:
     # Redundante Notes
     notes = target.get("notes", [])
     if isinstance(notes, list):
-        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index", 0), reverse=True):
+        for rn in sorted(analysis.get("redundant_notes", []), key=lambda x: x.get("keep_index") or 0, reverse=True):
             indices = rn.get("indices", [])
             keep_index = rn.get("keep_index", indices[0] if indices else None)
             reason = rn.get("reason", "redundant")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -707,13 +707,13 @@ async def cmd_curator(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
     if sub == "dryrun":
         thinking = await update.message.reply_text("Analysiere Profil...")
-        from agent.proactive.curator import run_dry_run
+        from agent.proactive.curator import _debug_dry_run
 
-        report = await run_dry_run(force=True)
+        report, debug_info = await _debug_dry_run(force=True)
         if report:
             await thinking.edit_text(report, parse_mode="Markdown")
         else:
-            await thinking.edit_text("Profil leer oder Analyse fehlgeschlagen.")
+            await thinking.edit_text(f"Fehlgeschlagen: {debug_info}")
 
     elif sub == "apply":
         thinking = await update.message.reply_text("Wende Vorschlag an...")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -711,7 +711,10 @@ async def cmd_curator(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
         report, debug_info = await _debug_dry_run(force=True)
         if report:
-            await thinking.edit_text(report, parse_mode="Markdown")
+            try:
+                await thinking.edit_text(report, parse_mode="Markdown")
+            except Exception:
+                await thinking.edit_text(report)
         else:
             await thinking.edit_text(f"Fehlgeschlagen: {debug_info}")
 


### PR DESCRIPTION
- Prompt: indices/keep_index explizit als Integer vorgeschrieben\n- _sanitize_analysis(): filtert vor _build_proposal alle Einträge mit String-Indizes oder ungültigen sections raus