### PR TITLE
feat: Phase 182 – Curator Hotfix-Serie + phase.md squash-fix

### DIFF
--- a/.claude/commands/phase.md
+++ b/.claude/commands/phase.md
@@ -86,9 +86,9 @@ gh pr create \
 
 Auto-Merge aktivieren:
 ```bash
-gh pr merge --auto --merge <PR-Nummer>
+gh pr merge --auto --squash <PR-Nummer>
 ```
-Falls Auto-Merge nicht verfügbar (Exit-Code ≠ 0): manuell mit `gh pr merge --merge <PR-Nummer>` nach CI.
+Falls Auto-Merge nicht verfügbar (Exit-Code ≠ 0): manuell mit `gh pr merge --squash <PR-Nummer>` nach CI.
 
 ### 7. CI abwarten
 ```bash

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 179** ✅ Fork-Agent Learning Loop – Batch-Analyse alle N Turns – _turn_counter + _MEMORY_NUDGE_INTERVAL (env, default 10) in chat_agent.py; every N turns, last N HumanMessages are joined and passed as batch text to apply_learning() as background Task; complements per-turn single-message learning with deeper pattern detection across multiple turns; 1341 tests green
 - **Phase 180** ✅ GitHub Actions auf Node.js 24 migrieren – actions/checkout, actions/setup-python in allen drei Workflows (test.yml, lint.yml, weekly-audit.yml) von v5 auf v6 (Node.js 24) aktualisiert; 1341 tests green
 - **Phase 181** ✅ Background Curator – wöchentliche Profil-Konsolidierung – agent/proactive/curator.py mit State-Management, Idle-Detection (memory.db mtime), LLM-Analyse (Sonnet), Proposal-Builder (archive statt delete, _pinned-Schutz), Dry-Run + manueller Review via /curator apply|cancel|status; bot/curator_scheduler.py stündlicher Background-Loop; 1383 tests green
+- **Phase 182** ✅ Curator Hotfix-Serie + phase.md squash-fix – 6 Folge-Fixes nach Phase 181: LLM-Timeout 30s→60s (#151), build_proposal robust gegen non-dict stale items + None sort-key (#152), Markdown-Fallback auf Plain Text (#153), _safe_int() für alle Index-Konvertierungen (#154-#156), _sanitize_analysis() + Prompt-Härtung gegen String-Indizes (#157); phase.md Auto-Merge-Flag --merge→--squash; 1383 tests green
 
 ---
 


### PR DESCRIPTION
## Änderungen
- README: Phase 182 Eintrag dokumentiert alle 6 Curator-Hotfixes (#151–#157)
- `.claude/commands/phase.md`: Auto-Merge-Flag korrigiert (`--merge` → `--squash`)

## Tests
1383 passed, 0 failures