### PR TITLE
feat: Phase 183 – Beziehungs-Alert: unerwähnte Entitäten proaktiv melden

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 180** ✅ GitHub Actions auf Node.js 24 migrieren – actions/checkout, actions/setup-python in allen drei Workflows (test.yml, lint.yml, weekly-audit.yml) von v5 auf v6 (Node.js 24) aktualisiert; 1341 tests green
 - **Phase 181** ✅ Background Curator – wöchentliche Profil-Konsolidierung – agent/proactive/curator.py mit State-Management, Idle-Detection (memory.db mtime), LLM-Analyse (Sonnet), Proposal-Builder (archive statt delete, _pinned-Schutz), Dry-Run + manueller Review via /curator apply|cancel|status; bot/curator_scheduler.py stündlicher Background-Loop; 1383 tests green
 - **Phase 182** ✅ Curator Hotfix-Serie + phase.md squash-fix – 6 Folge-Fixes nach Phase 181: LLM-Timeout 30s→60s (#151), build_proposal robust gegen non-dict stale items + None sort-key (#152), Markdown-Fallback auf Plain Text (#153), _safe_int() für alle Index-Konvertierungen (#154-#156), _sanitize_analysis() + Prompt-Härtung gegen String-Indizes (#157); phase.md Auto-Merge-Flag --merge→--squash; 1383 tests green
+- **Phase 183** ✅ Beziehungs-Alert – proaktive Erinnerung bei unerwähnten Entitäten – relationship_alert.py: ChromaDB-native $lt-Filter auf last_mentioned_at_ts (Float, neue Spalte in collector.py), Schwellwerte Person=14d/andere=30d, Anti-Spam-Cooldown 7d, einmaliger Backfill für Altdaten, MAX_ALERTS_PER_RUN=3; heartbeat.py: trigger_type-Branching + empathischer Prompt für relationship_alert; heartbeat_scheduler.py: _send_proactive() extrahiert, zweiter Check-Pfad nach time_trigger; 1409 tests green
 
 ---
 

--- a/agent/proactive/collector.py
+++ b/agent/proactive/collector.py
@@ -131,7 +131,9 @@ async def collect_entities(user_message: str, bot_response: str) -> None:
         if collection is None:
             return
 
-        now = datetime.now(timezone.utc).isoformat()
+        now_dt = datetime.now(timezone.utc)
+        now = now_dt.isoformat()
+        now_ts = now_dt.timestamp()
         ids, documents, metadatas = [], [], []
 
         for entity in entities:
@@ -151,6 +153,7 @@ async def collect_entities(user_message: str, bot_response: str) -> None:
                 "status": "open",
                 "created_at": now,
                 "last_mentioned_at": now,
+                "last_mentioned_at_ts": now_ts,
                 "mention_count": mention_count,
                 "source_context": entity["context"][:200],
             }

--- a/agent/proactive/heartbeat.py
+++ b/agent/proactive/heartbeat.py
@@ -179,21 +179,13 @@ async def _gather_heartbeat_context(trigger_item: dict) -> dict[str, str]:
     return {"profile": profile, "memory": memory, "sessions": sessions}
 
 
-async def generate_proactive_message(trigger_item: dict) -> str:
-    """Haiku generiert eine personalisierte proaktive Nachricht mit Profil/Memory/Session-Kontext."""
-    try:
-        from langchain_core.messages import HumanMessage
-
-        llm = _get_llm()
-        days = trigger_item.get("days_until_due", "?")
-        name = trigger_item.get("name", "")
-        due = trigger_item.get("due_date", "")
-        entity_type = trigger_item.get("entity_type", "")
-        context = trigger_item.get("source_context", "")
-
-        ctx = await _gather_heartbeat_context(trigger_item)
-
-        prompt = f"""Schreibe eine kurze, freundliche proaktive Telegram-Nachricht für Fabio.
+def _build_time_trigger_prompt(trigger_item: dict, ctx: dict[str, str]) -> str:
+    days = trigger_item.get("days_until_due", "?")
+    name = trigger_item.get("name", "")
+    due = trigger_item.get("due_date", "")
+    entity_type = trigger_item.get("entity_type", "")
+    context = trigger_item.get("source_context", "")
+    return f"""Schreibe eine kurze, freundliche proaktive Telegram-Nachricht für Fabio.
 
 === Persönliches Profil ===
 {ctx["profile"] or "(keine Profildaten)"}
@@ -215,6 +207,46 @@ Regeln:
 - Deutsch, keine URLs
 - Leere Sektionen ignorieren"""
 
+
+def _build_relationship_alert_prompt(trigger_item: dict, ctx: dict[str, str]) -> str:
+    name = trigger_item.get("name", "")
+    days = trigger_item.get("days_since_mention", "?")
+    entity_type = trigger_item.get("entity_type", "")
+    context = trigger_item.get("source_context", "")
+    return f"""Schreibe eine kurze, warme Erinnerung für Fabio.
+
+=== Persönliches Profil ===
+{ctx["profile"] or "(keine Profildaten)"}
+
+=== Frühere Sessions zu "{name}" ===
+{ctx["sessions"] or "(keine Erwähnungen)"}
+
+=== Trigger ===
+- {entity_type} "{name}" wurde seit {days} Tagen nicht mehr erwähnt
+- Letzter bekannter Kontext: {context}
+
+Regeln:
+- Max. 2 Sätze
+- Empathisch, nicht vorwurfsvoll ("Vermisst du eigentlich...", "Wie geht's eigentlich...")
+- Bei Personen: persönlich und warm. Bei Projekten: aktivierend ("liegt seit ... brach")
+- Kein "Guten Morgen", keine förmliche Begrüßung
+- Deutsch, keine URLs
+- Leere Sektionen ignorieren"""
+
+
+async def generate_proactive_message(trigger_item: dict) -> str:
+    """Haiku generiert eine personalisierte proaktive Nachricht mit Profil/Memory/Session-Kontext."""
+    try:
+        from langchain_core.messages import HumanMessage
+
+        llm = _get_llm()
+        ctx = await _gather_heartbeat_context(trigger_item)
+
+        if trigger_item.get("trigger_type") == "relationship_alert":
+            prompt = _build_relationship_alert_prompt(trigger_item, ctx)
+        else:
+            prompt = _build_time_trigger_prompt(trigger_item, ctx)
+
         response = await asyncio.wait_for(
             llm.ainvoke([HumanMessage(content=prompt)]),
             timeout=LLM_TIMEOUT,
@@ -229,6 +261,10 @@ Regeln:
 
 
 def _fallback_message(item: dict) -> str:
+    if item.get("trigger_type") == "relationship_alert":
+        name = item.get("name", "")
+        days = item.get("days_since_mention", "?")
+        return f"Du hast {name} seit {days} Tagen nicht erwähnt – alles ok?"
     name = item.get("name", "")
     days = item.get("days_until_due", "?")
     return f"Erinnerung: '{name}' ist in {days} Tag(en) fällig."

--- a/agent/proactive/relationship_alert.py
+++ b/agent/proactive/relationship_alert.py
@@ -1,0 +1,173 @@
+"""
+agent/proactive/relationship_alert.py – Phase 183 (Issue #108)
+
+Beziehungs-Alert: findet Entitäten die zu lange nicht mehr erwähnt wurden
+und gibt sie als Trigger-Items für den Heartbeat zurück.
+
+Schwellwerte:
+  person  → 14 Tage ohne Erwähnung
+  andere  → 30 Tage ohne Erwähnung
+
+Anti-Spam: pro Entität nicht häufiger als alle 7 Tage alarmieren.
+Backfill: bestehende Einträge ohne last_mentioned_at_ts werden beim ersten
+          Aufruf einmalig migriert (Marker-Datei verhindert Wiederholung).
+
+API:
+  find_unmentioned_entities(now_ts) → list[dict]
+  mark_alerted(entity_id) → None
+"""
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PERSON_THRESHOLD_DAYS = 14
+OTHER_THRESHOLD_DAYS = 30
+ALERT_COOLDOWN_DAYS = 7
+MAX_ALERTS_PER_RUN = 3
+
+_BACKFILL_MARKER = Path.home() / ".fabbot" / ".relationship_alert_backfill_done"
+_OTHER_TYPES = ("place", "event", "task")
+
+
+def _get_entities_collection():
+    from agent.proactive.collector import _get_entities_collection as _get_col
+
+    return _get_col()
+
+
+def _backfill_missing_timestamps(collection) -> int:
+    """Ergänzt last_mentioned_at_ts für Einträge ohne dieses Feld.
+
+    Parst den vorhandenen ISO-String last_mentioned_at und schreibt den
+    entsprechenden Unix-Float zurück. Nötig für Einträge die vor Phase 183
+    angelegt wurden.
+    """
+    try:
+        result = collection.get(include=["metadatas"])
+        if not result["ids"]:
+            return 0
+        ids_to_update, metas_to_update = [], []
+        for eid, meta in zip(result["ids"], result["metadatas"]):
+            if "last_mentioned_at_ts" in meta:
+                continue
+            iso = meta.get("last_mentioned_at", "")
+            if not iso:
+                continue
+            try:
+                dt = datetime.fromisoformat(iso)
+                ts = dt.timestamp()
+            except (ValueError, OSError):
+                continue
+            ids_to_update.append(eid)
+            metas_to_update.append({**meta, "last_mentioned_at_ts": ts})
+        if not ids_to_update:
+            return 0
+        collection.update(ids=ids_to_update, metadatas=metas_to_update)
+        logger.info(f"Backfill: {len(ids_to_update)} Entität(en) mit last_mentioned_at_ts ergänzt")
+        return len(ids_to_update)
+    except Exception as e:
+        logger.warning(f"Backfill fehlgeschlagen (non-critical): {e}")
+        return 0
+
+
+def _run_backfill_once(collection) -> None:
+    if _BACKFILL_MARKER.exists():
+        return
+    count = _backfill_missing_timestamps(collection)
+    try:
+        _BACKFILL_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _BACKFILL_MARKER.touch()
+    except Exception:
+        pass
+    if count:
+        logger.info(f"Einmaliger Backfill abgeschlossen: {count} Einträge migriert")
+
+
+def _should_alert(meta: dict, now_ts: float) -> bool:
+    """True wenn kein oder veralteter Alert-Marker (>= ALERT_COOLDOWN_DAYS)."""
+    last_alerted = meta.get("last_alerted_at_ts")
+    if not last_alerted:
+        return True
+    try:
+        return (now_ts - float(last_alerted)) >= ALERT_COOLDOWN_DAYS * 86400
+    except (TypeError, ValueError):
+        return True
+
+
+def _query_unmentioned(collection, entity_type: str, cutoff_ts: float, now_ts: float) -> list[dict]:
+    """Fragt ChromaDB nach Entitäten eines Typs die vor cutoff_ts zuletzt erwähnt wurden."""
+    try:
+        result = collection.get(
+            where={
+                "$and": [
+                    {"entity_type": {"$eq": entity_type}},
+                    {"last_mentioned_at_ts": {"$lt": cutoff_ts}},
+                ]
+            },
+            include=["metadatas"],
+        )
+    except Exception as e:
+        logger.warning(f"ChromaDB-Query für {entity_type} fehlgeschlagen: {e}")
+        return []
+    items = []
+    for eid, meta in zip(result.get("ids", []), result.get("metadatas", [])):
+        if not _should_alert(meta, now_ts):
+            continue
+        days = int((now_ts - float(meta["last_mentioned_at_ts"])) / 86400)
+        items.append(
+            {
+                "id": eid,
+                "name": meta.get("name", ""),
+                "entity_type": entity_type,
+                "source_context": meta.get("source_context", ""),
+                "last_mentioned_at": meta.get("last_mentioned_at", ""),
+                "days_since_mention": days,
+                "trigger_type": "relationship_alert",
+            }
+        )
+    return items
+
+
+def find_unmentioned_entities(now_ts: float | None = None) -> list[dict]:
+    """Findet Entitäten die zu lange nicht erwähnt wurden.
+
+    Gibt max. MAX_ALERTS_PER_RUN Items zurück, sortiert nach Tagen (längste zuerst).
+    Fail-safe: bei Fehler wird [] zurückgegeben.
+    """
+    try:
+        collection = _get_entities_collection()
+        if collection is None:
+            return []
+        if now_ts is None:
+            now_ts = datetime.now(timezone.utc).timestamp()
+        _run_backfill_once(collection)
+        person_cutoff = now_ts - PERSON_THRESHOLD_DAYS * 86400
+        other_cutoff = now_ts - OTHER_THRESHOLD_DAYS * 86400
+        alerts: list[dict] = []
+        alerts.extend(_query_unmentioned(collection, "person", person_cutoff, now_ts))
+        for etype in _OTHER_TYPES:
+            alerts.extend(_query_unmentioned(collection, etype, other_cutoff, now_ts))
+        alerts.sort(key=lambda x: x["days_since_mention"], reverse=True)
+        return alerts[:MAX_ALERTS_PER_RUN]
+    except Exception as e:
+        logger.warning(f"find_unmentioned_entities Fehler (non-critical): {e}")
+        return []
+
+
+def mark_alerted(entity_id: str) -> None:
+    """Setzt last_alerted_at_ts auf jetzt (Anti-Spam für 7 Tage)."""
+    try:
+        collection = _get_entities_collection()
+        if collection is None:
+            return
+        existing = collection.get(ids=[entity_id], include=["metadatas"])
+        if not existing["ids"]:
+            return
+        now_ts = datetime.now(timezone.utc).timestamp()
+        meta = {**existing["metadatas"][0], "last_alerted_at_ts": now_ts}
+        collection.update(ids=[entity_id], metadatas=[meta])
+    except Exception as e:
+        logger.warning(f"mark_alerted Fehler (non-critical): {e}")

--- a/bot/heartbeat_scheduler.py
+++ b/bot/heartbeat_scheduler.py
@@ -1,8 +1,12 @@
 """
-bot/heartbeat_scheduler.py – Phase 145 (Issue #92)
+bot/heartbeat_scheduler.py – Phase 145 (Issue #92), erweitert Phase 183 (Issue #108)
 
 Stündlicher Heartbeat: evaluiert Trigger, sendet proaktive Nachrichten
 mit Cooldown-Schutz (max. 1 Nachricht / 6h).
+
+Trigger-Priorität:
+  1. Time-Trigger (Fälligkeit in N Tagen)
+  2. Relationship-Alert (Entität seit >14/30 Tagen nicht erwähnt)
 """
 
 import asyncio
@@ -23,21 +27,9 @@ logger = logging.getLogger(__name__)
 _HEARTBEAT_INTERVAL = 3600  # 1 Stunde
 
 
-async def _run_heartbeat(bot, chat_id: int) -> None:
-    # Issue #102: API-Health-Check läuft immer, unabhängig von Cooldown/Mute
-    await run_api_health_check(bot, chat_id)
-
-    if is_on_cooldown() or is_muted():
-        return
-
-    pending = get_pending_items(limit=20)
-    triggered = evaluate_time_triggers(pending)
-    if not triggered:
-        return
-
-    trigger = min(triggered, key=lambda x: x.get("days_until_due", 99))
+async def _send_proactive(bot, chat_id: int, trigger: dict) -> None:
+    """Generiert und sendet eine proaktive Nachricht, setzt Cooldown, updated State."""
     message = await generate_proactive_message(trigger)
-
     await bot.send_message(chat_id=chat_id, text=message)
     set_cooldown()
     try:
@@ -52,7 +44,36 @@ async def _run_heartbeat(bot, chat_id: int) -> None:
         )
     except Exception as state_err:
         logger.warning(f"Heartbeat state update fehlgeschlagen (nicht kritisch): {state_err}")
-    logger.info(f"Proaktive Nachricht gesendet: {trigger.get('name')} ({trigger.get('days_until_due')}d)")
+    name = trigger.get("name", "?")
+    if trigger.get("trigger_type") == "relationship_alert":
+        logger.info(f"Relationship-Alert gesendet: {name} (seit {trigger.get('days_since_mention')}d nicht erwähnt)")
+    else:
+        logger.info(f"Proaktive Nachricht gesendet: {name} ({trigger.get('days_until_due')}d)")
+
+
+async def _run_heartbeat(bot, chat_id: int) -> None:
+    # Issue #102: API-Health-Check läuft immer, unabhängig von Cooldown/Mute
+    await run_api_health_check(bot, chat_id)
+
+    if is_on_cooldown() or is_muted():
+        return
+
+    pending = get_pending_items(limit=20)
+    triggered = evaluate_time_triggers(pending)
+    if triggered:
+        trigger = min(triggered, key=lambda x: x.get("days_until_due", 99))
+        await _send_proactive(bot, chat_id, trigger)
+        return
+
+    try:
+        from agent.proactive.relationship_alert import find_unmentioned_entities, mark_alerted
+
+        alerts = find_unmentioned_entities()
+        if alerts:
+            await _send_proactive(bot, chat_id, alerts[0])
+            mark_alerted(alerts[0]["id"])
+    except Exception as e:
+        logger.warning(f"Relationship-Alert Fehler (non-critical): {e}")
 
 
 async def run_heartbeat_scheduler(bot, chat_id: int) -> None:

--- a/tests/test_ph183_relationship_alert.py
+++ b/tests/test_ph183_relationship_alert.py
@@ -147,8 +147,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             results = find_unmentioned_entities(now_ts=now)
         assert len(results) == 1
         assert results[0]["name"] == "Steffi"
@@ -162,8 +164,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             results = find_unmentioned_entities(now_ts=now)
         assert any(r["name"] == "Salvador" for r in results)
 
@@ -179,10 +183,7 @@ class TestFindUnmentionedEntities:
         now = _now()
         count = MAX_ALERTS_PER_RUN + 2
         ids = [f"id{i}" for i in range(count)]
-        metadatas = [
-            _make_meta("person", f"Person{i}", PERSON_THRESHOLD_DAYS + 1 + i, now)
-            for i in range(count)
-        ]
+        metadatas = [_make_meta("person", f"Person{i}", PERSON_THRESHOLD_DAYS + 1 + i, now) for i in range(count)]
         # Alle kommen von der person-Query, andere Queries geben nichts zurück
         col = self._make_col_with_side_effects(
             {"ids": ids, "metadatas": metadatas},
@@ -190,8 +191,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             results = find_unmentioned_entities(now_ts=now)
         assert len(results) <= MAX_ALERTS_PER_RUN
 
@@ -205,8 +208,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             results = find_unmentioned_entities(now_ts=now)
         assert results[0]["name"] == "Older"
 
@@ -220,8 +225,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             results = find_unmentioned_entities(now_ts=now)
         assert results[0]["days_since_mention"] == int(days_ago)
 
@@ -232,8 +239,10 @@ class TestFindUnmentionedEntities:
             {"ids": [], "metadatas": []},
             {"ids": [], "metadatas": []},
         )
-        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
-             patch("agent.proactive.relationship_alert._run_backfill_once"):
+        with (
+            patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col),
+            patch("agent.proactive.relationship_alert._run_backfill_once"),
+        ):
             assert find_unmentioned_entities(now_ts=_now()) == []
 
 

--- a/tests/test_ph183_relationship_alert.py
+++ b/tests/test_ph183_relationship_alert.py
@@ -9,9 +9,7 @@ Testet den Beziehungs-Alert:
 """
 
 import time
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from agent.proactive.relationship_alert import (
     ALERT_COOLDOWN_DAYS,

--- a/tests/test_ph183_relationship_alert.py
+++ b/tests/test_ph183_relationship_alert.py
@@ -1,0 +1,295 @@
+"""
+tests/test_ph183_relationship_alert.py – Phase 183 (Issue #108)
+
+Testet den Beziehungs-Alert:
+- _should_alert: Cooldown-Logik
+- _query_unmentioned: ChromaDB-Query-Struktur + Ergebnis-Verarbeitung
+- find_unmentioned_entities: Schwellwerte, Sortierung, MAX_ALERTS_PER_RUN, Fail-safe
+- mark_alerted: Anti-Spam-Marker setzen
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from agent.proactive.relationship_alert import (
+    ALERT_COOLDOWN_DAYS,
+    MAX_ALERTS_PER_RUN,
+    OTHER_THRESHOLD_DAYS,
+    PERSON_THRESHOLD_DAYS,
+    _query_unmentioned,
+    _should_alert,
+    find_unmentioned_entities,
+    mark_alerted,
+)
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _make_meta(
+    entity_type: str,
+    name: str,
+    days_ago: float,
+    now: float,
+    last_alerted_days_ago: float | None = None,
+) -> dict:
+    ts = now - days_ago * 86400
+    meta = {
+        "entity_type": entity_type,
+        "name": name,
+        "source_context": f"Kontext zu {name}",
+        "last_mentioned_at": "2026-01-01T00:00:00+00:00",
+        "last_mentioned_at_ts": ts,
+    }
+    if last_alerted_days_ago is not None:
+        meta["last_alerted_at_ts"] = now - last_alerted_days_ago * 86400
+    return meta
+
+
+class TestShouldAlert:
+    def test_no_last_alerted_returns_true(self):
+        assert _should_alert({}, _now()) is True
+
+    def test_recent_alert_returns_false(self):
+        now = _now()
+        meta = {"last_alerted_at_ts": now - (ALERT_COOLDOWN_DAYS * 86400 - 3600)}
+        assert _should_alert(meta, now) is False
+
+    def test_old_alert_returns_true(self):
+        now = _now()
+        meta = {"last_alerted_at_ts": now - (ALERT_COOLDOWN_DAYS * 86400 + 3600)}
+        assert _should_alert(meta, now) is True
+
+    def test_exactly_at_boundary_returns_true(self):
+        now = _now()
+        meta = {"last_alerted_at_ts": now - ALERT_COOLDOWN_DAYS * 86400}
+        assert _should_alert(meta, now) is True
+
+    def test_invalid_value_returns_true(self):
+        assert _should_alert({"last_alerted_at_ts": "invalid"}, _now()) is True
+
+    def test_none_value_returns_true(self):
+        assert _should_alert({"last_alerted_at_ts": None}, _now()) is True
+
+
+class TestQueryUnmentioned:
+    def test_correct_where_clause_for_person(self):
+        now = _now()
+        cutoff = now - PERSON_THRESHOLD_DAYS * 86400
+        col = MagicMock()
+        col.get.return_value = {"ids": [], "metadatas": []}
+        _query_unmentioned(col, "person", cutoff, now)
+        where = col.get.call_args.kwargs["where"]
+        assert {"entity_type": {"$eq": "person"}} in where["$and"]
+        assert {"last_mentioned_at_ts": {"$lt": cutoff}} in where["$and"]
+
+    def test_returns_structured_trigger_item(self):
+        now = _now()
+        ts = now - 20 * 86400
+        meta = {
+            "name": "Steffi",
+            "source_context": "Steffis Geburtstag",
+            "last_mentioned_at": "2026-01-01T00:00:00+00:00",
+            "last_mentioned_at_ts": ts,
+        }
+        col = MagicMock()
+        col.get.return_value = {"ids": ["id1"], "metadatas": [meta]}
+        results = _query_unmentioned(col, "person", ts + 1, now)
+        assert len(results) == 1
+        item = results[0]
+        assert item["trigger_type"] == "relationship_alert"
+        assert item["entity_type"] == "person"
+        assert item["name"] == "Steffi"
+        assert item["days_since_mention"] == 20
+        assert item["id"] == "id1"
+
+    def test_anti_spam_suppresses_recently_alerted(self):
+        now = _now()
+        ts = now - 20 * 86400
+        meta = {
+            "name": "Marco",
+            "source_context": "ctx",
+            "last_mentioned_at": "2026-01-01T00:00:00+00:00",
+            "last_mentioned_at_ts": ts,
+            "last_alerted_at_ts": now - 3600,
+        }
+        col = MagicMock()
+        col.get.return_value = {"ids": ["id1"], "metadatas": [meta]}
+        results = _query_unmentioned(col, "person", ts + 1, now)
+        assert results == []
+
+    def test_chromadb_exception_returns_empty(self):
+        col = MagicMock()
+        col.get.side_effect = Exception("DB-Fehler")
+        results = _query_unmentioned(col, "person", 0.0, _now())
+        assert results == []
+
+    def test_empty_collection_returns_empty(self):
+        col = MagicMock()
+        col.get.return_value = {"ids": [], "metadatas": []}
+        results = _query_unmentioned(col, "person", 0.0, _now())
+        assert results == []
+
+
+class TestFindUnmentionedEntities:
+    def _make_col_with_side_effects(self, *per_call_results):
+        col = MagicMock()
+        col.get.side_effect = list(per_call_results)
+        return col
+
+    def test_person_found_when_above_threshold(self):
+        now = _now()
+        meta = _make_meta("person", "Steffi", PERSON_THRESHOLD_DAYS + 1, now)
+        col = self._make_col_with_side_effects(
+            {"ids": ["id1"], "metadatas": [meta]},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            results = find_unmentioned_entities(now_ts=now)
+        assert len(results) == 1
+        assert results[0]["name"] == "Steffi"
+
+    def test_other_type_found_when_above_30d_threshold(self):
+        now = _now()
+        meta = _make_meta("place", "Salvador", OTHER_THRESHOLD_DAYS + 1, now)
+        col = self._make_col_with_side_effects(
+            {"ids": [], "metadatas": []},
+            {"ids": ["id2"], "metadatas": [meta]},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            results = find_unmentioned_entities(now_ts=now)
+        assert any(r["name"] == "Salvador" for r in results)
+
+    def test_collection_unavailable_returns_empty(self):
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=None):
+            assert find_unmentioned_entities() == []
+
+    def test_exception_returns_empty(self):
+        with patch("agent.proactive.relationship_alert._get_entities_collection", side_effect=Exception("Crash")):
+            assert find_unmentioned_entities() == []
+
+    def test_max_alerts_per_run_respected(self):
+        now = _now()
+        count = MAX_ALERTS_PER_RUN + 2
+        ids = [f"id{i}" for i in range(count)]
+        metadatas = [
+            _make_meta("person", f"Person{i}", PERSON_THRESHOLD_DAYS + 1 + i, now)
+            for i in range(count)
+        ]
+        # Alle kommen von der person-Query, andere Queries geben nichts zurück
+        col = self._make_col_with_side_effects(
+            {"ids": ids, "metadatas": metadatas},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            results = find_unmentioned_entities(now_ts=now)
+        assert len(results) <= MAX_ALERTS_PER_RUN
+
+    def test_sorted_by_days_descending(self):
+        now = _now()
+        meta_newer = _make_meta("person", "Newer", PERSON_THRESHOLD_DAYS + 1, now)
+        meta_older = _make_meta("person", "Older", PERSON_THRESHOLD_DAYS + 10, now)
+        col = self._make_col_with_side_effects(
+            {"ids": ["id1", "id2"], "metadatas": [meta_newer, meta_older]},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            results = find_unmentioned_entities(now_ts=now)
+        assert results[0]["name"] == "Older"
+
+    def test_days_since_mention_correct(self):
+        now = _now()
+        days_ago = PERSON_THRESHOLD_DAYS + 3
+        meta = _make_meta("person", "Test", days_ago, now)
+        col = self._make_col_with_side_effects(
+            {"ids": ["id1"], "metadatas": [meta]},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            results = find_unmentioned_entities(now_ts=now)
+        assert results[0]["days_since_mention"] == int(days_ago)
+
+    def test_no_results_when_all_empty(self):
+        col = self._make_col_with_side_effects(
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+            {"ids": [], "metadatas": []},
+        )
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col), \
+             patch("agent.proactive.relationship_alert._run_backfill_once"):
+            assert find_unmentioned_entities(now_ts=_now()) == []
+
+
+class TestMarkAlerted:
+    def test_sets_last_alerted_at_ts(self):
+        existing_meta = {"entity_type": "person", "name": "Steffi", "last_mentioned_at_ts": _now() - 86400 * 20}
+        col = MagicMock()
+        col.get.return_value = {"ids": ["id1"], "metadatas": [existing_meta]}
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col):
+            mark_alerted("id1")
+        col.update.assert_called_once()
+        updated_meta = col.update.call_args.kwargs["metadatas"][0]
+        assert "last_alerted_at_ts" in updated_meta
+        assert isinstance(updated_meta["last_alerted_at_ts"], float)
+
+    def test_preserves_existing_metadata(self):
+        existing_meta = {"entity_type": "person", "name": "Steffi", "last_mentioned_at_ts": 1000.0}
+        col = MagicMock()
+        col.get.return_value = {"ids": ["id1"], "metadatas": [existing_meta]}
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col):
+            mark_alerted("id1")
+        updated_meta = col.update.call_args.kwargs["metadatas"][0]
+        assert updated_meta["name"] == "Steffi"
+        assert updated_meta["entity_type"] == "person"
+
+    def test_collection_unavailable_no_crash(self):
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=None):
+            mark_alerted("some-id")
+
+    def test_entity_not_found_no_crash(self):
+        col = MagicMock()
+        col.get.return_value = {"ids": [], "metadatas": []}
+        with patch("agent.proactive.relationship_alert._get_entities_collection", return_value=col):
+            mark_alerted("non-existent")
+        col.update.assert_not_called()
+
+    def test_exception_no_crash(self):
+        with patch("agent.proactive.relationship_alert._get_entities_collection", side_effect=Exception("Crash")):
+            mark_alerted("id1")
+
+
+class TestFallbackMessage:
+    def test_relationship_alert_fallback(self):
+        from agent.proactive.heartbeat import _fallback_message
+
+        item = {"trigger_type": "relationship_alert", "name": "Steffi", "days_since_mention": 17}
+        msg = _fallback_message(item)
+        assert "Steffi" in msg
+        assert "17" in msg
+
+    def test_time_trigger_fallback(self):
+        from agent.proactive.heartbeat import _fallback_message
+
+        item = {"name": "Geburtstag", "days_until_due": 3}
+        msg = _fallback_message(item)
+        assert "Geburtstag" in msg
+        assert "3" in msg


### PR DESCRIPTION
## Änderungen

- **collector.py**: `last_mentioned_at_ts` (Unix-Float) beim Upsert ergänzt → ChromaDB-nativer `$lt`-Filter möglich (kein Fetch-all mehr)
- **relationship_alert.py** (neu): `find_unmentioned_entities()` mit ChromaDB `$and`/`$lt`-Query, Schwellwerte Person=14d / andere=30d, Anti-Spam-Cooldown 7d pro Entität, einmaliger Backfill für Altdaten (Marker-Datei), max. 3 Alerts pro Run
- **heartbeat.py**: `trigger_type`-Branching in `generate_proactive_message()`, neuer empathischer Prompt für `relationship_alert`, `_fallback_message()` für beide Trigger-Typen
- **heartbeat_scheduler.py**: `_send_proactive()` extrahiert (DRY), zweiter Check-Pfad nach `evaluate_time_triggers()` – Time-Trigger hat Priorität, Relationship-Alert greift wenn keine Time-Trigger aktiv

## Tests

26 neue Tests, 1409 gesamt passed, 0 failures

Closes #108