### PR TITLE
fix: Supervisor-Routing für [Standort]/[PDF:] → chat_agent

### DIFF
--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -148,6 +148,12 @@ _PRE_ROUTING_RULES: list[tuple[tuple[str, ...], str, str]] = [
         "vision_agent",
         "foto-trigger",
     ),
+    # Phase 189: Standort- und PDF-Anhänge → chat_agent
+    (
+        ("[standort]", "[pdf:"),
+        "chat_agent",
+        "anhang-trigger",
+    ),
     # Issue #37: CPU/RAM/Disk direkt → system_agent, kein LLM-Call nötig
     (
         (


### PR DESCRIPTION
## Problem
Phase 189: `on_location` sendet `[Standort] Latitude: X, Longitude: Y` an `handle_message_text`, aber Supervisor routete zu FINISH (kein Response).

## Fix
`_PRE_ROUTING_RULES`: `[standort]` und `[pdf:` Prefix → `chat_agent` (deterministisch, kein LLM-Call).

## Test
Manuell getestet – Bot antwortet korrekt mit Ortsbeschreibung.