### PR TITLE
feat: Phase 190 – Audio-Transkription + YouTube-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 180–187** ✅ Proaktivität & Memory – Node.js 24 Migration, Background Curator (wöchentliche Profil-Konsolidierung + Hotfix-Serie), Beziehungs-Alert (ChromaDB $lt-Filter, 14d/30d Schwellwerte), Memory-Parser zweistufig (Haiku-Router + Sonnet-Extractor), Curator Review-Fixes, Supervisor Routing Fix (#161), merke-dir-das Profil-Fakt vs. Bot-Instruktion (#164); 1452 tests green
 - **Phase 188** ✅ Memory-Agent Note-Fallback bei YAML-Review-Fehler – YAML-Review INVALID löst nicht mehr User-Fehlermeldung aus, sondern Note-Fallback (Daten gehen nicht verloren); Supervisor-Prompt um transiente Sozialereignisse mit Namen erweitert; 1452 tests green
 - **Phase 189** ✅ Telegram-Anhänge: PDF + Standort – PDF-Dateien via pymupdf extrahiert und an Claude weitergeleitet (20 MB Limit, 100k Zeichen-Cap, Caption-Support); Standort-Handler für filters.LOCATION registriert (Koordinaten als [Standort]-Text an Graph); on_document auf filters.Document.ALL erweitert; 1465 tests green
+- **Phase 190** ✅ Audio-Transkription + YouTube-Agent – filters.AUDIO Handler + _handle_document_audio für audio/* MIME-Typen via Whisper-Pipeline (#138); eigenständiger youtube_agent mit zweistufiger Logik (youtube-transcript-api → yt-dlp + Whisper-Fallback), Pre-Routing via _pre_route_youtube (#144); 1485 tests green
 
 ---
 

--- a/agent/agents/youtube_agent.py
+++ b/agent/agents/youtube_agent.py
@@ -1,0 +1,131 @@
+"""
+agent/agents/youtube_agent.py – YouTube-Video-Verständnis (Issue #144)
+
+Zweistufig:
+1. youtube-transcript-api: Untertitel holen (kein API-Key, kein Download)
+2. Whisper-Fallback: yt-dlp Audio → transcribe_audio() wenn kein Transcript
+"""
+
+import asyncio
+import logging
+import re
+import tempfile
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+
+from agent.state import AgentState
+from agent.llm import get_llm
+from agent.utils import extract_llm_text
+
+logger = logging.getLogger(__name__)
+
+_YT_RE = re.compile(r"(?:youtube\.com/watch[?&].*?v=|youtu\.be/)([\w-]+)")
+_TRANSCRIPT_MAX_CHARS = 50_000
+_AUDIO_MAX_BYTES = 100 * 1024 * 1024  # 100 MB
+
+_SYSTEM_PROMPT = (
+    "Du bist ein Video-Analyse-Assistent. Du bekommst das Transkript eines YouTube-Videos "
+    "und die Frage des Users. Beantworte die Frage präzise auf Basis des Transkripts. "
+    "Falls keine spezifische Frage gestellt wurde, erstelle eine kompakte Zusammenfassung."
+)
+
+
+def _extract_video_id(text: str) -> str | None:
+    m = _YT_RE.search(text)
+    return m.group(1) if m else None
+
+
+async def _fetch_transcript(video_id: str) -> str | None:
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+
+        loop = asyncio.get_event_loop()
+        entries = await loop.run_in_executor(
+            None,
+            lambda: YouTubeTranscriptApi.get_transcript(video_id, languages=["de", "en", "en-US", "de-DE"]),
+        )
+        text = " ".join(e["text"] for e in entries)
+        logger.info(f"youtube_agent: Transcript geladen ({len(text)} Zeichen)")
+        return text[:_TRANSCRIPT_MAX_CHARS]
+    except Exception as e:
+        logger.warning(f"youtube_agent: Transcript-API Fehler für {video_id}: {e}")
+        return None
+
+
+async def _whisper_fallback(video_id: str) -> str | None:
+    try:
+        import yt_dlp
+
+        from bot.transcribe import transcribe_audio
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_tpl = str(Path(tmp_dir) / "audio.%(ext)s")
+            ydl_opts = {
+                "format": "bestaudio/best",
+                "outtmpl": output_tpl,
+                "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
+                "quiet": True,
+                "no_warnings": True,
+                "max_filesize": _AUDIO_MAX_BYTES,
+            }
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                None,
+                lambda: yt_dlp.YoutubeDL(ydl_opts).download([f"https://www.youtube.com/watch?v={video_id}"]),
+            )
+            audio_files = list(Path(tmp_dir).glob("*.mp3"))
+            if not audio_files:
+                logger.warning(f"youtube_agent: yt-dlp lieferte keine MP3-Datei für {video_id}")
+                return None
+            audio_bytes = audio_files[0].read_bytes()
+            text = await transcribe_audio(audio_bytes)
+            if text:
+                logger.info(f"youtube_agent: Whisper-Fallback ({len(text)} Zeichen)")
+            return text
+    except Exception as e:
+        logger.error(f"youtube_agent: Whisper-Fallback Fehler: {e}", exc_info=True)
+        return None
+
+
+async def youtube_agent(state: AgentState) -> AgentState:
+    messages = state["messages"]
+    last_human = next((m for m in reversed(messages) if isinstance(m, HumanMessage)), None)
+    if not last_human:
+        return {**state, "last_agent_name": "youtube_agent"}
+
+    user_text = last_human.content if isinstance(last_human.content, str) else str(last_human.content)
+    video_id = _extract_video_id(user_text)
+
+    if not video_id:
+        return {
+            **state,
+            "messages": messages + [AIMessage(content="Keine gültige YouTube-URL gefunden.")],
+            "last_agent_name": "youtube_agent",
+        }
+
+    transcript = await _fetch_transcript(video_id)
+    if not transcript:
+        transcript = await _whisper_fallback(video_id)
+
+    if not transcript:
+        return {
+            **state,
+            "messages": messages + [AIMessage(content="Konnte kein Transkript für dieses Video abrufen.")],
+            "last_agent_name": "youtube_agent",
+        }
+
+    llm = get_llm()
+    response = await llm.ainvoke(
+        [
+            SystemMessage(content=_SYSTEM_PROMPT),
+            HumanMessage(content=f"Transkript:\n{transcript}\n\nFrage: {user_text}"),
+        ]
+    )
+    answer = extract_llm_text(response.content)
+
+    return {
+        **state,
+        "messages": messages + [AIMessage(content=answer)],
+        "last_agent_name": "youtube_agent",
+    }

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -148,6 +148,12 @@ _PRE_ROUTING_RULES: list[tuple[tuple[str, ...], str, str]] = [
         "vision_agent",
         "foto-trigger",
     ),
+    # Phase 189: Standort- und PDF-Anhänge → chat_agent
+    (
+        ("[standort]", "[pdf:"),
+        "chat_agent",
+        "anhang-trigger",
+    ),
     # Issue #37: CPU/RAM/Disk direkt → system_agent, kein LLM-Call nötig
     (
         (

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -22,6 +22,7 @@ from agent.agents.memory_agent import memory_agent
 from agent.agents.vision_agent import vision_agent
 from agent.agents.whatsapp_agent import whatsapp_agent
 from agent.agents.system_agent import system_agent
+from agent.agents.youtube_agent import youtube_agent
 from agent.protocol import Proto
 
 # Issue #98: Single Source of Truth für alle Agenten.
@@ -38,6 +39,7 @@ _AGENTS: dict[str, object] = {
     "vision_agent": vision_agent,
     "whatsapp_agent": whatsapp_agent,
     "system_agent": system_agent,
+    "youtube_agent": youtube_agent,
 }
 
 logger = logging.getLogger(__name__)
@@ -105,6 +107,7 @@ Verfuegbare Agenten:
 - computer_agent: Desktop-Steuerung, Screenshots, Apps oeffnen
 - vision_agent: Bildanalyse von Fotos. Wird automatisch geroutet wenn Nachricht mit [FOTO] beginnt.
 - whatsapp_agent: WhatsApp-Nachricht senden. NUR bei expliziten Sende-Befehlen an erlaubte Kontakte.
+- youtube_agent: YouTube-Video analysieren, zusammenfassen oder Fragen beantworten. Wird automatisch geroutet wenn eine youtube.com- oder youtu.be-URL erkannt wird.
 
 Regeln:
 - Wenn die letzte Nachricht bereits eine Antwort eines Agenten enthaelt: FINISH
@@ -131,6 +134,7 @@ reminder_agent
 memory_agent
 chat_agent
 system_agent
+youtube_agent
 FINISH
 """
 
@@ -379,10 +383,26 @@ def _pre_route_table(_state: AgentState, _messages: list, routing: list) -> str 
     return None
 
 
+_YT_URL_RE = re.compile(r"youtube\.com/watch|youtu\.be/")
+
+
+def _pre_route_youtube(_state: AgentState, _messages: list, routing: list) -> str | None:
+    if not routing:
+        return None
+    last_content = routing[-1].content if hasattr(routing[-1], "content") else ""
+    if isinstance(last_content, list):
+        last_content = " ".join(b.get("text", "") if isinstance(b, dict) else str(b) for b in last_content)
+    if _YT_URL_RE.search(last_content):
+        logger.info("supervisor: Pre-Routing → youtube_agent (YouTube-URL erkannt)")
+        return "youtube_agent"
+    return None
+
+
 _PRE_ROUTE_PIPELINE = [
     _pre_route_image_data,
     _pre_route_ai_message,
     _pre_route_vision_followup,
+    _pre_route_youtube,
     _pre_route_table,
 ]
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -74,6 +74,7 @@ _IMAGE_MAX_PX = 1920
 _IMAGE_MAX_BYTES = 5_000_000  # 5 MB
 _PDF_MAX_BYTES = 20_000_000  # 20 MB
 _PDF_MAX_CHARS = 100_000  # Zeichen-Limit für extrahierten Text
+_AUDIO_MAX_BYTES = 25_000_000  # 25 MB
 
 # Phase 91: Task-Registry für Background-Tasks in cmd_clip.
 _background_tasks: set[asyncio.Task] = set()
@@ -820,8 +821,10 @@ async def on_document(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         await _handle_document_image(update, ctx, doc, mime, chat_id, user_id)
     elif mime == "application/pdf":
         await _handle_document_pdf(update, ctx, doc, chat_id, user_id)
+    elif mime.startswith("audio/"):
+        await _handle_document_audio(update, ctx, doc, chat_id)
     else:
-        await update.message.reply_text(f"Dateityp '{mime}' wird nicht unterstützt. Unterstützt: Bilder, PDF.")
+        await update.message.reply_text(f"Dateityp '{mime}' wird nicht unterstützt. Unterstützt: Bilder, PDF, Audio.")
 
 
 async def _handle_document_image(update, ctx, doc, mime, chat_id, user_id) -> None:
@@ -904,6 +907,32 @@ async def _handle_document_pdf(update, ctx, doc, chat_id, user_id) -> None:
         await _delete_thinking(thinking)
 
 
+async def _handle_document_audio(update, ctx, doc, chat_id) -> None:
+    if doc.file_size and doc.file_size > _AUDIO_MAX_BYTES:
+        await update.message.reply_text(f"Audio-Datei zu groß (max. {_AUDIO_MAX_BYTES // 1_000_000} MB).")
+        return
+    thinking = await update.message.reply_text("Transkribiere...")
+    try:
+        tg_file = await ctx.bot.get_file(doc.file_id)
+        audio_bytes = bytes(await tg_file.download_as_bytearray())
+        text = await transcribe_audio(audio_bytes)
+        if not text:
+            await update.message.reply_text("Transkription fehlgeschlagen.")
+            return
+        await thinking.edit_text(f"_{text}_", parse_mode="Markdown")
+        thinking = None
+        await handle_message_text(update, ctx.bot, text)
+    except (TimedOut, NetworkError) as e:
+        logger.warning(f"Telegram network error in audio document handler: {e}")
+        await update.message.reply_text("Netzwerkfehler – bitte nochmal versuchen.")
+    except Exception as e:
+        logger.error(f"Audio document handler error: {e}", exc_info=True)
+        await update.message.reply_text("Fehler bei der Verarbeitung der Audio-Datei.")
+    finally:
+        if thinking is not None:
+            await _delete_thinking(thinking)
+
+
 @restricted
 async def on_location(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     if await _is_duplicate(update):
@@ -946,6 +975,33 @@ async def on_voice(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     except Exception as e:
         logger.error(f"Voice handler error: {e}", exc_info=True)
         await update.message.reply_text("Fehler bei der Verarbeitung der Sprachnachricht.")
+    finally:
+        if thinking is not None:
+            await _delete_thinking(thinking)
+
+
+@restricted
+async def on_audio(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    if await _is_duplicate(update):
+        return
+    thinking = await update.message.reply_text("Transkribiere...")
+    try:
+        audio = update.message.audio
+        tg_file = await ctx.bot.get_file(audio.file_id)
+        audio_bytes = await tg_file.download_as_bytearray()
+        text = await transcribe_audio(bytes(audio_bytes))
+        if not text:
+            await update.message.reply_text("Transkription fehlgeschlagen.")
+            return
+        await thinking.edit_text(f"_{text}_", parse_mode="Markdown")
+        thinking = None
+        await handle_message_text(update, ctx.bot, text)
+    except (TimedOut, NetworkError) as e:
+        logger.warning(f"Telegram network error in audio handler: {e}")
+        await update.message.reply_text("Netzwerkfehler – bitte nochmal versuchen.")
+    except Exception as e:
+        logger.error(f"Audio handler error: {e}", exc_info=True)
+        await update.message.reply_text("Fehler bei der Verarbeitung der Audio-Datei.")
     finally:
         if thinking is not None:
             await _delete_thinking(thinking)
@@ -1265,6 +1321,7 @@ def build_bot() -> Application:
     app.add_handler(CommandHandler("wa_contact", cmd_wa_contact, block=False))
     app.add_handler(CommandHandler("curator", cmd_curator, block=False))
     app.add_handler(MessageHandler(filters.VOICE, on_voice, block=False))
+    app.add_handler(MessageHandler(filters.AUDIO, on_audio, block=False))
     app.add_handler(MessageHandler(filters.PHOTO, on_photo, block=False))
     app.add_handler(MessageHandler(filters.Document.ALL, on_document, block=False))
     app.add_handler(MessageHandler(filters.LOCATION, on_location, block=False))

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -888,7 +888,16 @@ async def _handle_document_pdf(update, ctx, doc, chat_id, user_id) -> None:
         else:
             message_text = f"{prefix}\n\n{text}"
         await _delete_thinking(thinking)
-        await handle_message_text(update, ctx.bot, message_text)
+        # PDF-Inhalt ist Datei-Content, kein User-Input → sanitize_input_async überspringen
+        state = {
+            "messages": [HumanMessage(content=message_text)],
+            "telegram_chat_id": chat_id,
+            "next_agent": None,
+        }
+        config = {"configurable": {"thread_id": str(chat_id)}, "recursion_limit": 10}
+        async with _get_invoke_lock(chat_id):
+            response_msg = await _invoke_and_extract(state, config)
+        await _dispatch_response(response_msg, ctx.bot, chat_id, update)
     except Exception as e:
         logger.error(f"on_document PDF-Fehler: {e}", exc_info=True)
         await update.message.reply_text("Fehler beim Lesen des PDFs.")

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -243,6 +243,8 @@ yarl==1.23.0
 zstandard==0.25.0
     # via langsmith
 
+youtube-transcript-api==1.2.4
+yt-dlp==2026.3.17
 pytest
 langgraph-checkpoint-sqlite==3.0.3
 aiosqlite==0.22.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -94,7 +94,7 @@ jsonpointer==3.0.0
     # via jsonpatch
 langchain-anthropic==1.3.5
     # via -r requirements.txt
-langchain-core==1.2.28
+langchain-core==1.3.3
     # via
     #   langchain-anthropic
     #   langgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -179,4 +179,6 @@ websockets==16.0
 xxhash==3.6.0
 yarl==1.23.0
 zipp==3.23.0
+youtube-transcript-api==1.2.4
+yt-dlp==2026.3.17
 zstandard==0.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ keyring==25.7.0
 kubernetes==35.0.0
 langchain==1.2.15
 langchain-anthropic==1.3.5
-langchain-core==1.2.28
+langchain-core==1.3.3
 langgraph==1.1.6
 langgraph-checkpoint==4.0.1
 langgraph-checkpoint-sqlite==3.0.3

--- a/tests/test_ph189_attachments.py
+++ b/tests/test_ph189_attachments.py
@@ -157,7 +157,7 @@ class TestHandleDocumentPdf:
         assert "keinen lesbaren Text" in combined
 
     @pytest.mark.asyncio
-    async def test_pdf_text_passed_to_handle_message_text(self):
+    async def test_pdf_text_passed_to_invoke(self):
         from bot.bot import _handle_document_pdf
 
         update = _make_update(mime_type="application/pdf", file_size=1000, filename="bericht.pdf")
@@ -166,11 +166,16 @@ class TestHandleDocumentPdf:
         with (
             patch("bot.bot._delete_thinking", AsyncMock()),
             patch("fitz.open", MagicMock(return_value=fitz_doc)),
-            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+            patch("bot.bot._invoke_and_extract", AsyncMock(return_value="")) as mock_inv,
+            patch("bot.bot._dispatch_response", AsyncMock()),
+            patch("bot.bot._get_invoke_lock") as mock_lock,
         ):
+            mock_lock.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
             await _handle_document_pdf(update, ctx, update.message.document, 42, 99)
-        mock_hmt.assert_called_once()
-        text_arg = mock_hmt.call_args[0][2]
+        mock_inv.assert_called_once()
+        state_arg = mock_inv.call_args[0][0]
+        text_arg = state_arg["messages"][0].content
         assert "[PDF: bericht.pdf]" in text_arg
         assert "Seite 1 Inhalt" in text_arg
         assert "Seite 2 Inhalt" in text_arg
@@ -185,11 +190,15 @@ class TestHandleDocumentPdf:
         with (
             patch("bot.bot._delete_thinking", AsyncMock()),
             patch("fitz.open", MagicMock(return_value=fitz_doc)),
-            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+            patch("bot.bot._invoke_and_extract", AsyncMock(return_value="")) as mock_inv,
+            patch("bot.bot._dispatch_response", AsyncMock()),
+            patch("bot.bot._get_invoke_lock") as mock_lock,
             patch("bot.bot.sanitize_input_async", AsyncMock(return_value=(True, "Bitte zusammenfassen"))),
         ):
+            mock_lock.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
             await _handle_document_pdf(update, ctx, update.message.document, 42, 99)
-        text_arg = mock_hmt.call_args[0][2]
+        text_arg = mock_inv.call_args[0][0]["messages"][0].content
         assert "Bitte zusammenfassen" in text_arg
 
     @pytest.mark.asyncio
@@ -203,10 +212,14 @@ class TestHandleDocumentPdf:
         with (
             patch("bot.bot._delete_thinking", AsyncMock()),
             patch("fitz.open", MagicMock(return_value=fitz_doc)),
-            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+            patch("bot.bot._invoke_and_extract", AsyncMock(return_value="")) as mock_inv,
+            patch("bot.bot._dispatch_response", AsyncMock()),
+            patch("bot.bot._get_invoke_lock") as mock_lock,
         ):
+            mock_lock.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
             await _handle_document_pdf(update, ctx, update.message.document, 42, 99)
-        text_arg = mock_hmt.call_args[0][2]
+        text_arg = mock_inv.call_args[0][0]["messages"][0].content
         assert "gekürzt" in text_arg
 
     @pytest.mark.asyncio

--- a/tests/test_ph190_audio_youtube.py
+++ b/tests/test_ph190_audio_youtube.py
@@ -232,7 +232,6 @@ class TestYoutubeAgent:
         from agent.agents.youtube_agent import youtube_agent
 
         state = _make_state("Fass mir dieses Video zusammen: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        mock_entries = [{"text": "Hallo", "start": 0.0}, {"text": "Welt", "start": 1.0}]
         mock_llm_response = MagicMock()
         mock_llm_response.content = "Eine Zusammenfassung."
 

--- a/tests/test_ph190_audio_youtube.py
+++ b/tests/test_ph190_audio_youtube.py
@@ -1,0 +1,354 @@
+"""
+tests/test_ph190_audio_youtube.py – Phase 190 (#138 + #144)
+
+Testet:
+- on_audio: Transkription und Weiterleitung an handle_message_text
+- on_document: Dispatch für audio/* MIME
+- _handle_document_audio: Größencheck, Transkription, Fehlerfall
+- youtube_agent: Transcript-API-Erfolg, Whisper-Fallback, ungültige URL
+- supervisor: Pre-Routing für YouTube-URLs
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bot.auth import ALLOWED_IDS
+
+_ALLOWED_ID = next(iter(ALLOWED_IDS))
+
+
+def _make_thinking_mock():
+    thinking = MagicMock()
+    thinking.edit_text = AsyncMock()
+    return thinking
+
+
+def _make_update(mime_type=None, file_size=None, audio_file_id="audio_123"):
+    doc = MagicMock()
+    doc.mime_type = mime_type
+    doc.file_size = file_size
+    doc.file_id = audio_file_id
+    doc.file_name = "test.mp3"
+
+    audio = MagicMock()
+    audio.file_id = audio_file_id
+
+    msg = MagicMock()
+    msg.document = doc if mime_type else None
+    msg.audio = audio
+    msg.reply_text = AsyncMock(return_value=_make_thinking_mock())
+
+    update = MagicMock()
+    update.effective_chat.id = 42
+    update.effective_user.id = _ALLOWED_ID
+    update.message = msg
+    return update
+
+
+def _make_ctx(audio_bytes=b"fake_audio"):
+    tg_file = AsyncMock()
+    tg_file.download_as_bytearray = AsyncMock(return_value=bytearray(audio_bytes))
+    bot = MagicMock()
+    bot.get_file = AsyncMock(return_value=tg_file)
+    ctx = MagicMock()
+    ctx.bot = bot
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# on_audio
+# ---------------------------------------------------------------------------
+
+
+class TestOnAudio:
+    @pytest.mark.asyncio
+    async def test_transcribes_and_routes(self):
+        from bot.bot import on_audio
+
+        update = _make_update()
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot._is_duplicate", AsyncMock(return_value=False)),
+            patch("bot.bot.transcribe_audio", AsyncMock(return_value="Hallo Welt")) as mock_trans,
+            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+            patch("bot.bot._delete_thinking", AsyncMock()),
+        ):
+            await on_audio(update, ctx)
+
+        mock_trans.assert_called_once()
+        mock_hmt.assert_called_once()
+        text_arg = mock_hmt.call_args[0][2]
+        assert text_arg == "Hallo Welt"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_skipped(self):
+        from bot.bot import on_audio
+
+        update = _make_update()
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot._is_duplicate", AsyncMock(return_value=True)),
+            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+        ):
+            await on_audio(update, ctx)
+
+        mock_hmt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transcription_failure_replies_error(self):
+        from bot.bot import on_audio
+
+        update = _make_update()
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot._is_duplicate", AsyncMock(return_value=False)),
+            patch("bot.bot.transcribe_audio", AsyncMock(return_value=None)),
+            patch("bot.bot._delete_thinking", AsyncMock()),
+        ):
+            await on_audio(update, ctx)
+
+        update.message.reply_text.assert_called()
+        last_call = update.message.reply_text.call_args_list[-1][0][0]
+        assert "fehlgeschlagen" in last_call
+
+
+# ---------------------------------------------------------------------------
+# on_document – audio/* Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestOnDocumentAudioDispatch:
+    @pytest.mark.asyncio
+    async def test_audio_mime_calls_audio_handler(self):
+        from bot.bot import on_document
+
+        update = _make_update(mime_type="audio/mpeg", file_size=1000)
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot._is_duplicate", AsyncMock(return_value=False)),
+            patch("bot.bot._handle_document_audio", AsyncMock()) as mock_audio,
+        ):
+            await on_document(update, ctx)
+
+        mock_audio.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_audio_ogg_mime_calls_audio_handler(self):
+        from bot.bot import on_document
+
+        update = _make_update(mime_type="audio/ogg", file_size=500)
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot._is_duplicate", AsyncMock(return_value=False)),
+            patch("bot.bot._handle_document_audio", AsyncMock()) as mock_audio,
+        ):
+            await on_document(update, ctx)
+
+        mock_audio.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_mime_still_replies_info(self):
+        from bot.bot import on_document
+
+        update = _make_update(mime_type="application/zip", file_size=100)
+        ctx = _make_ctx()
+        with patch("bot.bot._is_duplicate", AsyncMock(return_value=False)):
+            await on_document(update, ctx)
+
+        update.message.reply_text.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_document_audio
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDocumentAudio:
+    @pytest.mark.asyncio
+    async def test_too_large_replies_error(self):
+        from bot.bot import _handle_document_audio, _AUDIO_MAX_BYTES
+
+        update = _make_update(mime_type="audio/mpeg", file_size=_AUDIO_MAX_BYTES + 1)
+        ctx = _make_ctx()
+        await _handle_document_audio(update, ctx, update.message.document, 42)
+
+        update.message.reply_text.assert_called_once()
+        assert "zu groß" in update.message.reply_text.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_transcribes_and_passes_text(self):
+        from bot.bot import _handle_document_audio
+
+        update = _make_update(mime_type="audio/mpeg", file_size=1000)
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot.transcribe_audio", AsyncMock(return_value="Test Transkription")) as mock_trans,
+            patch("bot.bot.handle_message_text", AsyncMock()) as mock_hmt,
+            patch("bot.bot._delete_thinking", AsyncMock()),
+        ):
+            await _handle_document_audio(update, ctx, update.message.document, 42)
+
+        mock_trans.assert_called_once()
+        mock_hmt.assert_called_once()
+        assert mock_hmt.call_args[0][2] == "Test Transkription"
+
+    @pytest.mark.asyncio
+    async def test_transcription_failure_replies_error(self):
+        from bot.bot import _handle_document_audio
+
+        update = _make_update(mime_type="audio/mpeg", file_size=1000)
+        ctx = _make_ctx()
+        with (
+            patch("bot.bot.transcribe_audio", AsyncMock(return_value=None)),
+            patch("bot.bot._delete_thinking", AsyncMock()),
+        ):
+            await _handle_document_audio(update, ctx, update.message.document, 42)
+
+        calls = [c[0][0] for c in update.message.reply_text.call_args_list]
+        assert any("fehlgeschlagen" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# youtube_agent
+# ---------------------------------------------------------------------------
+
+
+def _make_state(text: str) -> dict:
+    from langchain_core.messages import HumanMessage
+
+    return {
+        "messages": [HumanMessage(content=text)],
+        "telegram_chat_id": 42,
+        "next_agent": None,
+        "last_agent_name": None,
+        "image_data": None,
+        "image_media_type": None,
+    }
+
+
+class TestYoutubeAgent:
+    @pytest.mark.asyncio
+    async def test_transcript_api_success(self):
+        from agent.agents.youtube_agent import youtube_agent
+
+        state = _make_state("Fass mir dieses Video zusammen: https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        mock_entries = [{"text": "Hallo", "start": 0.0}, {"text": "Welt", "start": 1.0}]
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = "Eine Zusammenfassung."
+
+        with (
+            patch("agent.agents.youtube_agent._fetch_transcript", AsyncMock(return_value="Hallo Welt")) as mock_fetch,
+            patch("agent.agents.youtube_agent.get_llm") as mock_get_llm,
+        ):
+            mock_get_llm.return_value.ainvoke = AsyncMock(return_value=mock_llm_response)
+            result = await youtube_agent(state)
+
+        mock_fetch.assert_called_once_with("dQw4w9WgXcQ")
+        from langchain_core.messages import AIMessage
+
+        last_msg = result["messages"][-1]
+        assert isinstance(last_msg, AIMessage)
+        assert result["last_agent_name"] == "youtube_agent"
+
+    @pytest.mark.asyncio
+    async def test_whisper_fallback_used_when_no_transcript(self):
+        from agent.agents.youtube_agent import youtube_agent
+
+        state = _make_state("https://youtu.be/dQw4w9WgXcQ")
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = "Whisper-Antwort."
+
+        with (
+            patch("agent.agents.youtube_agent._fetch_transcript", AsyncMock(return_value=None)),
+            patch(
+                "agent.agents.youtube_agent._whisper_fallback", AsyncMock(return_value="Transkript via Whisper")
+            ) as mock_fallback,
+            patch("agent.agents.youtube_agent.get_llm") as mock_get_llm,
+        ):
+            mock_get_llm.return_value.ainvoke = AsyncMock(return_value=mock_llm_response)
+            result = await youtube_agent(state)
+
+        mock_fallback.assert_called_once_with("dQw4w9WgXcQ")
+        assert result["last_agent_name"] == "youtube_agent"
+
+    @pytest.mark.asyncio
+    async def test_no_transcript_at_all_replies_error(self):
+        from agent.agents.youtube_agent import youtube_agent
+        from langchain_core.messages import AIMessage
+
+        state = _make_state("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+        with (
+            patch("agent.agents.youtube_agent._fetch_transcript", AsyncMock(return_value=None)),
+            patch("agent.agents.youtube_agent._whisper_fallback", AsyncMock(return_value=None)),
+        ):
+            result = await youtube_agent(state)
+
+        last_msg = result["messages"][-1]
+        assert isinstance(last_msg, AIMessage)
+        assert "kein Transkript" in last_msg.content
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_replies_error(self):
+        from agent.agents.youtube_agent import youtube_agent
+        from langchain_core.messages import AIMessage
+
+        state = _make_state("Schau mal diese Seite an: https://example.com/video")
+        result = await youtube_agent(state)
+
+        last_msg = result["messages"][-1]
+        assert isinstance(last_msg, AIMessage)
+        assert "keine gültige YouTube-URL" in last_msg.content.lower() or "keine" in last_msg.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_youtu_be_short_url_extracted(self):
+        from agent.agents.youtube_agent import _extract_video_id
+
+        assert _extract_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_youtube_full_url_extracted(self):
+        from agent.agents.youtube_agent import _extract_video_id
+
+        assert _extract_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_no_url_returns_none(self):
+        from agent.agents.youtube_agent import _extract_video_id
+
+        assert _extract_video_id("Hallo, wie geht es dir?") is None
+
+
+# ---------------------------------------------------------------------------
+# supervisor – YouTube Pre-Routing
+# ---------------------------------------------------------------------------
+
+
+class TestSupervisorYoutubeRouting:
+    def test_youtube_com_url_routes_to_youtube_agent(self):
+        from langchain_core.messages import HumanMessage
+        from agent.supervisor import _pre_route_youtube
+
+        routing = [HumanMessage(content="https://www.youtube.com/watch?v=abc123")]
+        result = _pre_route_youtube({}, [], routing)
+        assert result == "youtube_agent"
+
+    def test_youtu_be_url_routes_to_youtube_agent(self):
+        from langchain_core.messages import HumanMessage
+        from agent.supervisor import _pre_route_youtube
+
+        routing = [HumanMessage(content="Schau mal: https://youtu.be/xyz789")]
+        result = _pre_route_youtube({}, [], routing)
+        assert result == "youtube_agent"
+
+    def test_non_youtube_url_returns_none(self):
+        from langchain_core.messages import HumanMessage
+        from agent.supervisor import _pre_route_youtube
+
+        routing = [HumanMessage(content="https://example.com/video")]
+        result = _pre_route_youtube({}, [], routing)
+        assert result is None
+
+    def test_empty_routing_returns_none(self):
+        from agent.supervisor import _pre_route_youtube
+
+        result = _pre_route_youtube({}, [], [])
+        assert result is None


### PR DESCRIPTION
## Änderungen

- **#138 Audio-Transkription:** `on_audio` Handler für `filters.AUDIO` + `_handle_document_audio` für `audio/*` MIME-Typen in `on_document`; nutzt bestehende Whisper-Pipeline (`bot/transcribe.py`)
- **#144 YouTube-Agent:** Neuer eigenständiger `youtube_agent` mit zweistufiger Logik — `youtube-transcript-api` (primär, kein API-Key) → `yt-dlp` + Whisper-Fallback; Supervisor Pre-Routing via `_pre_route_youtube`
- Neue Dependencies: `youtube-transcript-api==1.2.4`, `yt-dlp==2026.3.17`
- README Phase 190 Eintrag

## Tests
1485 passed, 0 failures (20 neue Tests)