### PR TITLE
fix: basic-ftp 5.3.1 – Dependabot Alert #22

### DIFF
--- a/whatsapp_service/package-lock.json
+++ b/whatsapp_service/package-lock.json
@@ -399,9 +399,9 @@
       "optional": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

- `basic-ftp` transitive Dependency von `whatsapp-web.js → puppeteer → proxy-agent → get-uri` auf `5.3.1` aktualisiert
- Behebt GHSA-rpmf-866q-6p89: DoS via unbounded multiline FTP control response buffering (High)
- Nur `package-lock.json` geändert, keine direkten Dependencies

## Test plan

- [ ] CI grün
- [ ] Dependabot Alert #22 schließt sich nach Merge