### PR TITLE
feat: Phase 193 – Bug-Fixes & Security-Enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Was wurde geändert?
+
+<!-- Kurze Beschreibung der Änderung -->
+
+## Checklist
+
+- [ ] Tests geschrieben / angepasst
+- [ ] `pytest` lokal grün
+- [ ] **Security:** Neue `on_*`-Handler und `_handle_*`-Funktionen die User-Input verarbeiten rufen `sanitize_input_async` / `_sanitize_and_validate` / `handle_message_text` auf
+- [ ] Keine Secrets im Code
+- [ ] Bot nach Deployment getestet

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ tail -f ~/.fabbot/fabbot.log      # live log
 - **Phase 190** ✅ Audio-Transkription + YouTube-Agent – filters.AUDIO Handler + _handle_document_audio für audio/* MIME-Typen via Whisper-Pipeline (#138); eigenständiger youtube_agent mit zweistufiger Logik (youtube-transcript-api → yt-dlp + Whisper-Fallback), Pre-Routing via _pre_route_youtube (#144); 1485 tests green
 - **Phase 191** ✅ Musik-Erkennung bei Audio-Transkription – NoSpeechDetectedError via Whisper no_speech_prob + Unicode-Script-Heuristik; klare Fehlermeldung statt Halluzinations-Transkript bei Musik-Dateien; 1485 tests green
 - **Phase 192** ✅ Audio-Dokument Caption-Support – Caption bei audio/* Dokumenten wird als Benutzeranweisung an den Agenten weitergegeben (analog PDF-Handler); sanitize_input_async für Caption; Transkript + Caption als strukturierter Text; 1486 tests green
+- **Phase 193** ✅ Bug-Fixes & Security-Enforcement – _truncate_profile_yaml hard-truncate Fallback wenn erste Sektion > 8000 Zeichen (#181); Fork-Agent Batch-Learning Log-Level DEBUG→INFO (#147); AST-basierter Enforcement-Test für sanitize_input_async in allen MessageHandlern + PR-Template (#182); 1497 tests green
 
 ---
 

--- a/agent/agents/chat_agent.py
+++ b/agent/agents/chat_agent.py
@@ -492,7 +492,7 @@ async def chat_agent(state: AgentState) -> AgentState:
                 task = asyncio.create_task(_apply_learning(batch_text))
                 _background_tasks.add(task)
                 task.add_done_callback(_background_tasks.discard)
-                logger.debug(
+                logger.info(
                     f"Fork-Agent Batch-Learning gestartet (Turn {_turn_counter}, {len(human_messages)} Nachrichten)."
                 )
         except Exception as e:

--- a/agent/proactive/curator.py
+++ b/agent/proactive/curator.py
@@ -139,14 +139,18 @@ def _truncate_profile_yaml(profile: dict) -> str:
 
     sections: list[str] = []
     total = 0
-    skipped = 0
+    added_keys = 0
     for key, value in profile.items():
         chunk = yaml.dump({key: value}, allow_unicode=True, default_flow_style=False, sort_keys=False)
         if total + len(chunk) > _YAML_MAX_CHARS:
-            skipped += 1
-        else:
-            sections.append(chunk)
-            total += len(chunk)
+            if not sections:  # erste Sektion bereits zu groß → hard truncate
+                sections.append(chunk[:_YAML_MAX_CHARS])
+                added_keys = 1
+            break
+        sections.append(chunk)
+        total += len(chunk)
+        added_keys += 1
+    skipped = len(profile) - added_keys
     if skipped:
         sections.append(f"# ... [{skipped} Sektionen gekürzt]\n")
     return "".join(sections)

--- a/tests/test_curator_truncate.py
+++ b/tests/test_curator_truncate.py
@@ -1,0 +1,78 @@
+"""
+tests/test_curator_truncate.py
+
+Issue #181: _truncate_profile_yaml – Fallback wenn erste Sektion > 8000 Zeichen.
+
+Testet:
+- Erste Sektion allein > _YAML_MAX_CHARS → Ergebnis nicht leer, hard truncate auf max
+- Normale Truncation: Sektion 1 passt, Sektion 2 zu groß → break, Hinweis am Ende
+- Alles passt rein → unveränderter Output
+- skipped-Hinweis zeigt korrekte Anzahl übersprungener Sektionen
+"""
+
+
+from agent.proactive.curator import _truncate_profile_yaml, _YAML_MAX_CHARS
+
+
+def _make_big_value(size: int) -> str:
+    return "x" * size
+
+
+class TestTruncateProfileYaml:
+    def test_small_profile_unchanged(self):
+        profile = {"name": "Fabio", "city": "Berlin"}
+        result = _truncate_profile_yaml(profile)
+        assert "Fabio" in result
+        assert "Berlin" in result
+        assert len(result) <= _YAML_MAX_CHARS
+
+    def test_first_section_oversized_not_empty(self):
+        """Bug #181: erste Sektion > _YAML_MAX_CHARS → kein leeres Ergebnis."""
+        profile = {"notes": _make_big_value(_YAML_MAX_CHARS + 1000)}
+        result = _truncate_profile_yaml(profile)
+        assert len(result) > 0, "Ergebnis darf nicht leer sein"
+        assert len(result) <= _YAML_MAX_CHARS
+
+    def test_first_section_oversized_hard_truncated(self):
+        """Hard-truncated Sektion hat exakt _YAML_MAX_CHARS Zeichen."""
+        profile = {"notes": _make_big_value(_YAML_MAX_CHARS * 2)}
+        result = _truncate_profile_yaml(profile)
+        assert len(result) == _YAML_MAX_CHARS
+
+    def test_normal_truncation_first_section_kept(self):
+        """Sektion 1 passt, Sektion 2 überschreitet Limit → Sektion 1 enthalten."""
+        profile = {
+            "name": "Fabio",
+            "notes": _make_big_value(_YAML_MAX_CHARS),
+        }
+        result = _truncate_profile_yaml(profile)
+        assert "Fabio" in result
+        assert "name" in result
+
+    def test_normal_truncation_shows_skipped_hint(self):
+        """Wenn Sektionen übersprungen wurden → Hinweis am Ende."""
+        profile = {
+            "name": "Fabio",
+            "notes": _make_big_value(_YAML_MAX_CHARS),
+            "extra": "more",
+        }
+        result = _truncate_profile_yaml(profile)
+        assert "gekürzt" in result
+
+    def test_skipped_count_correct(self):
+        """skipped-Hinweis zeigt korrekte Anzahl."""
+        profile = {
+            "name": "Fabio",
+            "notes": _make_big_value(_YAML_MAX_CHARS),
+            "extra": "more",
+        }
+        result = _truncate_profile_yaml(profile)
+        assert "[2 Sektionen gekürzt]" in result
+
+    def test_multiple_sections_fit(self):
+        """Mehrere kleine Sektionen passen alle rein."""
+        profile = {f"key{i}": f"value{i}" for i in range(10)}
+        result = _truncate_profile_yaml(profile)
+        for i in range(10):
+            assert f"value{i}" in result
+        assert "gekürzt" not in result

--- a/tests/test_curator_truncate.py
+++ b/tests/test_curator_truncate.py
@@ -10,7 +10,6 @@ Testet:
 - skipped-Hinweis zeigt korrekte Anzahl übersprungener Sektionen
 """
 
-
 from agent.proactive.curator import _truncate_profile_yaml, _YAML_MAX_CHARS
 
 

--- a/tests/test_sanitize_enforcement.py
+++ b/tests/test_sanitize_enforcement.py
@@ -1,0 +1,70 @@
+"""
+tests/test_sanitize_enforcement.py
+
+Issue #182: sanitize_input_async als strukturelle Pflicht für alle MessageHandler.
+
+Prüft per AST/Regex, dass jede via MessageHandler registrierte Funktion in bot.py
+sanitize_input_async, _sanitize_and_validate oder handle_message_text aufruft –
+direkt oder über _handle_*-Delegaten (transitiv eine Ebene tief).
+Schlägt automatisch an wenn ein neuer Handler ohne Sanitierung hinzugefügt wird.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+BOT_PY = Path(__file__).parent.parent / "bot" / "bot.py"
+
+_SANITIZE_MARKERS = frozenset({"sanitize_input_async", "_sanitize_and_validate", "handle_message_text"})
+
+
+def _function_body(source: str, func_name: str) -> str:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            lines = source.splitlines()
+            return "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    return ""
+
+
+def _combined_body(source: str, func_name: str) -> str:
+    """Funktionskörper + alle direkt aufgerufenen _handle_*-Delegaten (eine Ebene)."""
+    body = _function_body(source, func_name)
+    for delegate in re.findall(r"\b(_handle_\w+)\s*\(", body):
+        body += "\n" + _function_body(source, delegate)
+    return body
+
+
+def _registered_message_handlers(source: str) -> list[str]:
+    return re.findall(r"MessageHandler\s*\([^,]+,\s*(\w+)", source)
+
+
+class TestSanitizeEnforcement:
+    def test_bot_py_exists(self):
+        assert BOT_PY.exists(), f"bot.py nicht gefunden: {BOT_PY}"
+
+    def test_message_handlers_registered(self):
+        source = BOT_PY.read_text()
+        handlers = _registered_message_handlers(source)
+        assert len(handlers) > 0, "Keine MessageHandler in bot.py gefunden"
+
+    def test_all_message_handlers_sanitize(self):
+        """Jeder MessageHandler muss sanitize_input_async / _sanitize_and_validate
+        / handle_message_text im Funktionskörper oder seinen _handle_*-Delegaten aufrufen."""
+        source = BOT_PY.read_text()
+        handlers = _registered_message_handlers(source)
+        missing = []
+        for name in handlers:
+            body = _combined_body(source, name)
+            if not any(marker in body for marker in _SANITIZE_MARKERS):
+                missing.append(name)
+        assert not missing, (
+            "Diese MessageHandler fehlt sanitize_input_async / "
+            "_sanitize_and_validate / handle_message_text:\n" + "\n".join(f"  - {n}" for n in missing)
+        )
+
+    def test_sanitize_markers_present_in_source(self):
+        """Sanity-Check: Sanitize-Funktionen existieren überhaupt in bot.py."""
+        source = BOT_PY.read_text()
+        for marker in _SANITIZE_MARKERS:
+            assert marker in source, f"Marker '{marker}' fehlt komplett in bot.py"


### PR DESCRIPTION
## Änderungen

- **fix #181:** `_truncate_profile_yaml` – hard-truncate Fallback wenn erste Sektion > 8000 Zeichen (LLM sah leeres Profil)
- **fix #147:** Fork-Agent Batch-Learning Log-Level `DEBUG` → `INFO` (Einträge waren unsichtbar)
- **chore #182:** AST-basierter Enforcement-Test (`test_sanitize_enforcement.py`) – schlägt automatisch an wenn neuer `MessageHandler` ohne Sanitierung registriert wird; PR-Template mit Security-Checkbox

## Tests

1497 passed, 0 failures (1 pre-existing failure in test_ph145_heartbeat unrelated zu diesen Änderungen)