### PR TITLE
fix: ruff in CI pinnen – kein Version-Mismatch mehr

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install -r requirements-ci.txt
 
       - name: Check style
         run: ruff check .


### PR DESCRIPTION
CI nutzte `pip install ruff` (unpinned, holt neueste Version), lokal läuft ruff==0.15.12 aus requirements-ci.txt. Bei Versionsunterschied schlägt `ruff format --check` mit anderen Formatierungsregeln an.\n\nFix: `pip install -r requirements-ci.txt` im lint-Workflow.\n\nZusätzlich: lokaler `.git/hooks/pre-commit` der `ruff format` auf staged .py-Dateien prüft bevor commit.