### PR TITLE
fix: zwei CI-Test-Flakes (curator idle + audit LogCaptureHandler)

### DIFF
--- a/tests/test_ph181_curator.py
+++ b/tests/test_ph181_curator.py
@@ -117,7 +117,11 @@ class TestIdleDetection:
     def test_returns_seconds_since_mtime(self, memory_db):
         from agent.proactive.curator import get_idle_seconds
 
-        with patch("agent.proactive.curator._MEMORY_DB", memory_db):
+        # focus_mode (activity.json) vorrangig – für den mtime-Fallback ausschalten
+        with (
+            patch("agent.proactive.focus_mode.get_idle_seconds", return_value=0.0),
+            patch("agent.proactive.curator._MEMORY_DB", memory_db),
+        ):
             idle = get_idle_seconds()
         assert idle >= 0
 
@@ -127,6 +131,7 @@ class TestIdleDetection:
         nonexistent = tmp_path / "no.db"
         nonexistent_log = tmp_path / "no.log"
         with (
+            patch("agent.proactive.focus_mode.get_idle_seconds", return_value=0.0),
             patch("agent.proactive.curator._MEMORY_DB", nonexistent),
             patch("agent.proactive.curator._FABBOT_LOG", nonexistent_log),
         ):
@@ -142,7 +147,10 @@ class TestIdleDetection:
         db.write_bytes(b"")
         old_time = time.time() - 7200  # 2h ago
         os.utime(db, (old_time, old_time))
-        with patch("agent.proactive.curator._MEMORY_DB", db):
+        with (
+            patch("agent.proactive.focus_mode.get_idle_seconds", return_value=0.0),
+            patch("agent.proactive.curator._MEMORY_DB", db),
+        ):
             idle = get_idle_seconds()
         assert idle >= 7000
 

--- a/tests/test_ph92_fixes.py
+++ b/tests/test_ph92_fixes.py
@@ -175,13 +175,19 @@ class TestAuditSetupLogger:
 
         assert callable(setup_audit_logger)
 
+    @staticmethod
+    def _file_handlers(audit_module) -> list:
+        """Nur FileHandler – ignoriert pytest-eigene LogCaptureHandler.
+        pytest haengt wegen propagate=False seine caplog-Handler direkt an
+        fabbot.audit; die sind fuer diese Tests irrelevant (CI-Flake-Quelle)."""
+        return [h for h in audit_module.audit_logger.handlers if isinstance(h, logging.FileHandler)]
+
     def test_no_filehandler_on_import(self) -> None:
         """Beim Import von agent.audit wird kein FileHandler geöffnet."""
         import agent.audit as audit_module
 
-        # Nach setup_method sind alle Handler entfernt und Flag False
-        # → kein Handler sollte vorhanden sein
-        assert len(audit_module.audit_logger.handlers) == 0
+        # Nach setup_method ist kein FileHandler vorhanden (Flag False)
+        assert self._file_handlers(audit_module) == []
 
     def test_setup_adds_handler(self, tmp_path) -> None:
         """setup_audit_logger() fügt einen FileHandler hinzu."""
@@ -192,8 +198,9 @@ class TestAuditSetupLogger:
         with patch("agent.audit.AUDIT_LOG_PATH", log_path):
             setup_audit_logger()
 
-        assert len(audit_module.audit_logger.handlers) == 1
-        assert isinstance(audit_module.audit_logger.handlers[0], logging.FileHandler)
+        file_handlers = self._file_handlers(audit_module)
+        assert len(file_handlers) == 1
+        assert isinstance(file_handlers[0], logging.FileHandler)
 
     def test_setup_idempotent(self, tmp_path) -> None:
         """Mehrfache Aufrufe von setup_audit_logger() fügen keinen zweiten Handler hinzu."""
@@ -206,7 +213,7 @@ class TestAuditSetupLogger:
             setup_audit_logger()
             setup_audit_logger()
 
-        assert len(audit_module.audit_logger.handlers) == 1
+        assert len(self._file_handlers(audit_module)) == 1
 
     def test_initialized_flag_set(self, tmp_path) -> None:
         """_audit_initialized wird nach setup auf True gesetzt."""


### PR DESCRIPTION
Behebt zwei vorbestehende, zeit-/umgebungsabhängige Test-Flakes, die die CI auf master rot machten und jeden PR blockierten.

## Flake 1 – `TestIdleDetection` (zeitabhängig)
`get_idle_seconds()` ruft seit **Phase 221** zuerst `focus_mode.get_idle_seconds()` (liest `activity.json`) und kehrt mit dessen Wert zurück, **bevor** der von den Tests gepatchte mtime-Fallback erreicht wird. Sobald der Bot lief und `activity.json` schrieb, schlugen die Phase-181-Tests fehl.
→ Tests mocken jetzt `focus_mode.get_idle_seconds=0.0`.

## Flake 2 – `TestAuditSetupLogger` (nur in CI)
Weil `fabbot.audit` `propagate=False` hat, hängt pytest seine **caplog-`LogCaptureHandler`** direkt an diesen Logger (lokal landen sie am Root-Logger – daher nur in CI sichtbar). Die Tests zählten `len(handlers) == 0/1` und schlugen mit `assert 2 == 0` fehl.
→ Tests filtern jetzt auf `FileHandler` – die eigentliche Aussage (kein/genau ein FileHandler) bleibt, pytest-Infrastruktur wird ignoriert.

**Produktivcode unverändert** – reine Test-Fixes. Volle Suite: 1824 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)