### PR TITLE
refactor: HITL via interrupt() für calendar_agent (#274)

### DIFF
--- a/agent/agents/calendar.py
+++ b/agent/agents/calendar.py
@@ -3,10 +3,10 @@ import json
 import subprocess
 from datetime import datetime, timedelta, date
 from langchain_core.messages import SystemMessage, AIMessage, HumanMessage
+from langgraph.types import interrupt
 from agent.state import AgentState
 from agent.audit import log_action
 from agent.llm import get_llm
-from agent.protocol import Proto
 from agent.utils import extract_llm_text
 
 
@@ -233,11 +233,37 @@ async def calendar_agent(state: AgentState) -> AgentState:
         if end_time:
             confirm_text += f" bis {end_time}"
 
+        # Phase 223 (Issue #274): HITL via LangGraph interrupt() statt Magic-String-Return.
+        # bot.py erkennt den Interrupt, holt Bestätigung und resumed via Command(resume=...).
+        # Defensive: Werte aus decision lesen (Source of Truth post-resume, Node läuft neu).
+        decision = interrupt(
+            {
+                "type": "create_event",
+                "title": title,
+                "start_time": start_time,
+                "end_time": end_time,
+                "display": confirm_text,
+            }
+        )
+
+        if not isinstance(decision, dict) or not decision.get("confirmed"):
+            log_action(
+                "calendar_agent",
+                "create_event",
+                f"user rejected: {title}",
+                state.get("telegram_chat_id"),
+                status="rejected",
+            )
+            msg = "Termin abgebrochen."
+            return {"messages": [AIMessage(content=msg)], "last_agent_result": msg, "last_agent_name": "calendar_agent"}
+
+        c_title = decision.get("title", title)
+        c_start = decision.get("start_time", start_time)
+        c_end = decision.get("end_time", end_time)
+        output = calendar_event_create(c_title, c_start, c_end, state.get("telegram_chat_id") or 0)
         return {
-            "messages": [AIMessage(content=f"{Proto.CONFIRM_CREATE_EVENT}{title}::{start_time}::{end_time}")],
-            "next_agent": None,
-            "_confirm_display": confirm_text,
-            "last_agent_result": None,
+            "messages": [AIMessage(content=output)],
+            "last_agent_result": output,
             "last_agent_name": "calendar_agent",
         }
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -52,7 +52,6 @@ from bot.tts import speak_and_send, set_tts_enabled, is_tts_enabled, stop_speaki
 from agent.security import sanitize_input_async, check_action_rate_limit
 from agent.audit import log_action, log_blocked
 from agent.protocol import Proto
-from agent.agents.calendar import calendar_event_create
 from agent.agents.computer import computer_agent_execute, _screenshot_to_telegram_bytes
 from agent.agents.clip_agent import clip_agent, clip_agent_write
 from agent.agents.vision_agent import analyze_image_direct
@@ -307,6 +306,18 @@ async def _handle_interrupt(interrupt_value: dict, bot: Bot, chat_id: int) -> di
             "content": content,
         }
 
+    if action_type == "create_event":
+        display = interrupt_value.get("display", "Neuer Termin")
+        confirmed = await request_confirmation(bot, chat_id, "calendar_agent", display)
+        if not confirmed:
+            return {"confirmed": False}
+        return {
+            "confirmed": True,
+            "title": interrupt_value.get("title", ""),
+            "start_time": interrupt_value.get("start_time", ""),
+            "end_time": interrupt_value.get("end_time", ""),
+        }
+
     logger.warning(f"_handle_interrupt: unbekannter Typ {action_type!r} – ablehnen")
     return {"confirmed": False}
 
@@ -437,22 +448,6 @@ async def _handle_confirm_computer(response_msg: str, bot: Bot, chat_id: int, **
         log_action("computer_agent", action, "user rejected", chat_id, status="rejected")
 
 
-async def _handle_confirm_create_event(response_msg: str, bot: Bot, chat_id: int, **_) -> None:
-    parts = response_msg[len(Proto.CONFIRM_CREATE_EVENT) :].split("::")
-    title = parts[0] if len(parts) > 0 else ""
-    start_time = parts[1] if len(parts) > 1 else ""
-    end_time = parts[2] if len(parts) > 2 else ""
-    confirmed = await request_confirmation(bot, chat_id, "calendar_agent", f"Neuer Termin: {title} am {start_time}")
-    if confirmed:
-        output = calendar_event_create(title, start_time, end_time, chat_id)
-        await bot.send_message(chat_id=chat_id, text=output)
-        if len(output) <= _TTS_MAX_HITL_OUTPUT:
-            await speak_and_send(output, bot, chat_id)
-        await _update_memory(chat_id, f"Kalendereintrag erstellt: {title} um {start_time}\nErgebnis: {output}")
-    else:
-        log_action("calendar_agent", "create_event", f"user rejected: {title}", chat_id, status="rejected")
-
-
 async def _handle_confirm_whatsapp(response_msg: str, bot: Bot, chat_id: int, **_) -> None:
     parts = response_msg[len(Proto.CONFIRM_WHATSAPP) :].split("::", 1)
     whatsapp_name = parts[0] if len(parts) > 0 else ""
@@ -482,7 +477,6 @@ async def _handle_confirm_whatsapp(response_msg: str, bot: Bot, chat_id: int, **
 _RESPONSE_DISPATCH: list[tuple[str, Any]] = [
     (Proto.SCREENSHOT, _handle_screenshot),
     (Proto.CONFIRM_COMPUTER, _handle_confirm_computer),
-    (Proto.CONFIRM_CREATE_EVENT, _handle_confirm_create_event),
     (Proto.CONFIRM_WHATSAPP, _handle_confirm_whatsapp),
 ]
 

--- a/tests/test_ph223_hitl_calendar.py
+++ b/tests/test_ph223_hitl_calendar.py
@@ -1,0 +1,164 @@
+"""
+Phase 223 (Issue #274, ex #243): HITL via LangGraph interrupt() für calendar_agent.
+
+Verifiziert dass calendar_agent bei create_event statt eines
+__CONFIRM_CREATE_EVENT__-Magic-Strings einen Pregel-Interrupt auslöst,
+der mit Command(resume=...) fortgesetzt wird.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import Command
+
+
+def _llm_response(text: str) -> MagicMock:
+    mock = MagicMock()
+    mock.content = text
+    return mock
+
+
+def _build_single_node_graph(node_fn, state_type):
+    g = StateGraph(state_type)
+    g.add_node("agent", node_fn)
+    g.add_edge(START, "agent")
+    g.add_edge("agent", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+_CREATE_JSON = (
+    '{"action": "create_event", "title": "Zahnarzt", '
+    '"start_time": "2026-07-01T10:00:00", "end_time": "2026-07-01T11:00:00"}'
+)
+
+
+class TestCalendarAgentInterrupt:
+    @pytest.mark.asyncio
+    async def test_create_event_emits_interrupt(self) -> None:
+        from agent.agents.calendar import calendar_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_CREATE_JSON))
+
+        with patch("agent.agents.calendar.get_llm", return_value=mock_llm):
+            app = _build_single_node_graph(calendar_agent, AgentState)
+            config = {"configurable": {"thread_id": "cal-1"}}
+            result = await app.ainvoke(
+                {"messages": [HumanMessage(content="trag zahnarzt ein")], "telegram_chat_id": 42},
+                config,
+            )
+
+        interrupts = result.get("__interrupt__")
+        assert interrupts is not None
+        assert len(interrupts) == 1
+        value = interrupts[0].value
+        assert value["type"] == "create_event"
+        assert value["title"] == "Zahnarzt"
+        assert value["start_time"] == "2026-07-01T10:00:00"
+        assert value["end_time"] == "2026-07-01T11:00:00"
+
+    @pytest.mark.asyncio
+    async def test_resume_confirmed_creates_event(self) -> None:
+        from agent.agents.calendar import calendar_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_CREATE_JSON))
+
+        with (
+            patch("agent.agents.calendar.get_llm", return_value=mock_llm),
+            patch(
+                "agent.agents.calendar.calendar_event_create", return_value="Termin erstellt: Zahnarzt"
+            ) as mock_create,
+        ):
+            app = _build_single_node_graph(calendar_agent, AgentState)
+            config = {"configurable": {"thread_id": "cal-confirmed"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="trag ein")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(
+                Command(
+                    resume={
+                        "confirmed": True,
+                        "title": "Zahnarzt",
+                        "start_time": "2026-07-01T10:00:00",
+                        "end_time": "2026-07-01T11:00:00",
+                    }
+                ),
+                config,
+            )
+
+        mock_create.assert_called_once()
+        args = mock_create.call_args[0]
+        assert args[0] == "Zahnarzt"
+        assert args[1] == "2026-07-01T10:00:00"
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs
+        assert "erstellt" in ai_msgs[-1].content.lower()
+
+    @pytest.mark.asyncio
+    async def test_resume_rejected_returns_abbruch(self) -> None:
+        from agent.agents.calendar import calendar_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_CREATE_JSON))
+
+        with (
+            patch("agent.agents.calendar.get_llm", return_value=mock_llm),
+            patch("agent.agents.calendar.calendar_event_create") as mock_create,
+        ):
+            app = _build_single_node_graph(calendar_agent, AgentState)
+            config = {"configurable": {"thread_id": "cal-rejected"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="trag ein")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(Command(resume={"confirmed": False}), config)
+
+        mock_create.assert_not_called()
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs
+        assert "abgebrochen" in ai_msgs[-1].content.lower()
+
+
+class TestBotHandleInterruptCreateEvent:
+    """_handle_interrupt() in bot.py – Brücke für type=create_event."""
+
+    @pytest.mark.asyncio
+    async def test_create_event_confirmed_passes_fields(self) -> None:
+        import bot.bot as bot_mod
+
+        with patch("bot.bot.request_confirmation", AsyncMock(return_value=True)):
+            decision = await bot_mod._handle_interrupt(
+                {
+                    "type": "create_event",
+                    "title": "Zahnarzt",
+                    "start_time": "2026-07-01T10:00:00",
+                    "end_time": "2026-07-01T11:00:00",
+                    "display": "Neuer Termin",
+                },
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision["confirmed"] is True
+        assert decision["title"] == "Zahnarzt"
+        assert decision["start_time"] == "2026-07-01T10:00:00"
+        assert decision["end_time"] == "2026-07-01T11:00:00"
+
+    @pytest.mark.asyncio
+    async def test_create_event_rejected_returns_false(self) -> None:
+        import bot.bot as bot_mod
+
+        with patch("bot.bot.request_confirmation", AsyncMock(return_value=False)):
+            decision = await bot_mod._handle_interrupt(
+                {"type": "create_event", "title": "X", "start_time": "2026-07-01T10:00:00", "end_time": ""},
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision == {"confirmed": False}


### PR DESCRIPTION
Task 1/4 aus Meta-Issue #274 (HITL-Cluster).

## Änderung
Migriert `create_event` vom `__CONFIRM_CREATE_EVENT__:`-Magic-String auf das Graph-native `interrupt()`-Pattern aus Phase 212.

- **`calendar.py`**: `interrupt({"type": "create_event", ...})` statt `Proto.CONFIRM_CREATE_EVENT`-Return. Werte werden post-resume aus `decision` gelesen (Source of Truth gegen LLM-Drift bei Node-Re-Execution).
- **`bot.py`**: `_handle_interrupt()`-Branch für `create_event`; `_handle_confirm_create_event` + `_RESPONSE_DISPATCH`-Eintrag entfernt.
- **Tests**: `test_ph223_hitl_calendar.py` – Interrupt-Emission, confirmed-Pfad (ruft `calendar_event_create`), rejected-Pfad, `_handle_interrupt`-Bridge.

## Bewusst belassen
- `chat_agent.py` History-Cleanup für `__CONFIRM_CREATE_EVENT__:` (bereinigt alte Checkpoint-Messages – konsistent mit Phase 212, die terminal/file-Cleanups ebenfalls beließ).
- `Proto.CONFIRM_CREATE_EVENT` + `is_*`-Check – werden im finalen Cleanup nach allen vier Migrationen entfernt.

## Test
Volle Suite grün (1829 passed). Referenz-Tests `test_ph212` weiterhin grün.

Teil von #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)