### PR TITLE
refactor: HITL via interrupt() für computer_agent (#274)

### DIFF
--- a/agent/agents/computer.py
+++ b/agent/agents/computer.py
@@ -3,6 +3,7 @@ import base64
 import subprocess
 from pathlib import Path
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.types import interrupt
 from agent.state import AgentState
 from agent.audit import log_action
 from agent.llm import get_llm
@@ -137,39 +138,54 @@ async def computer_agent(state: AgentState) -> AgentState:
     elif action == "click":
         x = parsed.get("x", 0)
         y = parsed.get("y", 0)
-        return {
-            "messages": [AIMessage(content=f"{Proto.CONFIRM_COMPUTER}click:{x}:{y}:")],
-            "next_agent": None,
-            "last_agent_result": None,
-            "last_agent_name": "computer_agent",
-        }
+        text = ""
+        display = f"click @ ({x}, {y})"
 
     elif action == "type":
         text = parsed.get("text", "")
+        x = y = 0
         valid, reason = _validate_typewrite_text(text)
         if not valid:
             return _err(f"Ungültiger Text: {reason}")
-        return {
-            "messages": [AIMessage(content=f"{Proto.CONFIRM_COMPUTER}type:0:0:{text}")],
-            "next_agent": None,
-            "last_agent_result": None,
-            "last_agent_name": "computer_agent",
-        }
+        display = f"type: {text}"
 
     elif action == "open_app":
         app = parsed.get("app", "")
+        x = y = 0
         valid, clean_app = _validate_app_name(app)
         if not valid:
             return _err(f"Ungültiger App-Name: {clean_app}")
-        return {
-            "messages": [AIMessage(content=f"{Proto.CONFIRM_COMPUTER}open_app:0:0:{clean_app}")],
-            "next_agent": None,
-            "last_agent_result": None,
-            "last_agent_name": "computer_agent",
-        }
+        text = clean_app
+        display = f"open_app: {clean_app}"
 
     else:
         return _err(f"Unbekannte Aktion: {action}")
+
+    # Phase 224 (Issue #274): HITL via LangGraph interrupt() statt Magic-String-Return.
+    # bot.py erkennt den Interrupt, holt Bestätigung + Rate-Limit und resumed via Command(resume=...).
+    # Defensive: Werte aus decision lesen (Source of Truth post-resume, Node läuft neu).
+    decision = interrupt({"type": "computer", "action": action, "x": x, "y": y, "text": text, "display": display})
+
+    if not isinstance(decision, dict) or not decision.get("confirmed"):
+        log_action("computer_agent", action, "user rejected", state.get("telegram_chat_id"), status="rejected")
+        msg = "Aktion abgebrochen."
+        return {"messages": [AIMessage(content=msg)], "last_agent_result": msg, "last_agent_name": "computer_agent"}
+
+    if not decision.get("rate_limit_ok", True):
+        log_action("computer_agent", action, "action-rate-limited", state.get("telegram_chat_id"), status="blocked")
+        msg = "Rate Limit: zu viele Aktionen – bitte kurz warten."
+        return {"messages": [AIMessage(content=msg)], "last_agent_result": msg, "last_agent_name": "computer_agent"}
+
+    c_action = decision.get("action", action)
+    c_x = decision.get("x", x)
+    c_y = decision.get("y", y)
+    c_text = decision.get("text", text)
+    output = computer_agent_execute(c_action, c_x, c_y, c_text, state.get("telegram_chat_id") or 0)
+    return {
+        "messages": [AIMessage(content=output)],
+        "last_agent_result": output,
+        "last_agent_name": "computer_agent",
+    }
 
 
 def computer_agent_execute(action: str, x: int, y: int, text: str, chat_id: int) -> str:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -52,7 +52,7 @@ from bot.tts import speak_and_send, set_tts_enabled, is_tts_enabled, stop_speaki
 from agent.security import sanitize_input_async, check_action_rate_limit
 from agent.audit import log_action, log_blocked
 from agent.protocol import Proto
-from agent.agents.computer import computer_agent_execute, _screenshot_to_telegram_bytes
+from agent.agents.computer import _screenshot_to_telegram_bytes
 from agent.agents.clip_agent import clip_agent, clip_agent_write
 from agent.agents.vision_agent import analyze_image_direct
 from bot.whatsapp import (
@@ -306,6 +306,21 @@ async def _handle_interrupt(interrupt_value: dict, bot: Bot, chat_id: int) -> di
             "content": content,
         }
 
+    if action_type == "computer":
+        display = interrupt_value.get("display", "Desktop-Aktion")
+        confirmed = await request_confirmation(bot, chat_id, "computer_agent", display)
+        if not confirmed:
+            return {"confirmed": False}
+        rate_limit_ok = check_action_rate_limit(chat_id, "destructive")
+        return {
+            "confirmed": True,
+            "rate_limit_ok": rate_limit_ok,
+            "action": interrupt_value.get("action", ""),
+            "x": interrupt_value.get("x", 0),
+            "y": interrupt_value.get("y", 0),
+            "text": interrupt_value.get("text", ""),
+        }
+
     if action_type == "create_event":
         display = interrupt_value.get("display", "Neuer Termin")
         confirmed = await request_confirmation(bot, chat_id, "calendar_agent", display)
@@ -428,26 +443,6 @@ async def _handle_screenshot(response_msg: str, bot: Bot, chat_id: int, **_) -> 
     # bei Follow-up-Fragen den Screenshot-Kontext kennt.
 
 
-async def _handle_confirm_computer(response_msg: str, bot: Bot, chat_id: int, **_) -> None:
-    parts = response_msg[len(Proto.CONFIRM_COMPUTER) :].split(":", 3)
-    action = parts[0] if len(parts) > 0 else ""
-    x = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
-    y = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
-    text_arg = parts[3] if len(parts) > 3 else ""
-    display = f"{action}: {text_arg}" if text_arg else f"{action} @ ({x}, {y})"
-    confirmed = await request_confirmation(bot, chat_id, "computer_agent", display)
-    if confirmed:
-        if not check_action_rate_limit(chat_id, "destructive"):
-            await bot.send_message(chat_id=chat_id, text="⚠️ Rate Limit: zu viele Aktionen – bitte kurz warten.")
-            log_action("computer_agent", action, "action-rate-limited", chat_id, status="blocked")
-            return
-        output = computer_agent_execute(action, x, y, text_arg, chat_id)
-        await bot.send_message(chat_id=chat_id, text=output)
-        await _update_memory(chat_id, f"Desktop-Aktion ausgefuehrt: {display}\nErgebnis: {output}")
-    else:
-        log_action("computer_agent", action, "user rejected", chat_id, status="rejected")
-
-
 async def _handle_confirm_whatsapp(response_msg: str, bot: Bot, chat_id: int, **_) -> None:
     parts = response_msg[len(Proto.CONFIRM_WHATSAPP) :].split("::", 1)
     whatsapp_name = parts[0] if len(parts) > 0 else ""
@@ -476,7 +471,6 @@ async def _handle_confirm_whatsapp(response_msg: str, bot: Bot, chat_id: int, **
 
 _RESPONSE_DISPATCH: list[tuple[str, Any]] = [
     (Proto.SCREENSHOT, _handle_screenshot),
-    (Proto.CONFIRM_COMPUTER, _handle_confirm_computer),
     (Proto.CONFIRM_WHATSAPP, _handle_confirm_whatsapp),
 ]
 

--- a/tests/test_ph224_hitl_computer.py
+++ b/tests/test_ph224_hitl_computer.py
@@ -1,0 +1,192 @@
+"""
+Phase 224 (Issue #274, ex #242): HITL via LangGraph interrupt() für computer_agent.
+
+Verifiziert dass computer_agent (click/type/open_app) statt eines
+__CONFIRM_COMPUTER__-Magic-Strings einen Pregel-Interrupt auslöst,
+der mit Command(resume=...) fortgesetzt wird. Screenshot bleibt unverändert.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import Command
+
+
+def _build_single_node_graph(node_fn, state_type):
+    g = StateGraph(state_type)
+    g.add_node("agent", node_fn)
+    g.add_edge(START, "agent")
+    g.add_edge("agent", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+async def _run_until_interrupt(text: str, thread_id: str):
+    from agent.agents.computer import computer_agent
+    from agent.state import AgentState
+
+    mock_llm = AsyncMock()
+    with patch("agent.agents.computer.get_llm", return_value=mock_llm):
+        app = _build_single_node_graph(computer_agent, AgentState)
+        config = {"configurable": {"thread_id": thread_id}}
+        result = await app.ainvoke(
+            {"messages": [HumanMessage(content=text)], "telegram_chat_id": 42},
+            config,
+        )
+    return result
+
+
+class TestComputerAgentInterrupt:
+    @pytest.mark.asyncio
+    async def test_click_emits_interrupt(self) -> None:
+        result = await _run_until_interrupt("klick auf 100, 200", "comp-click")
+        interrupts = result.get("__interrupt__")
+        assert interrupts is not None and len(interrupts) == 1
+        value = interrupts[0].value
+        assert value["type"] == "computer"
+        assert value["action"] == "click"
+        assert value["x"] == 100
+        assert value["y"] == 200
+
+    @pytest.mark.asyncio
+    async def test_type_emits_interrupt(self) -> None:
+        result = await _run_until_interrupt("tippe Hallo Welt", "comp-type")
+        value = result.get("__interrupt__")[0].value
+        assert value["type"] == "computer"
+        assert value["action"] == "type"
+        assert value["text"] == "hallo welt"
+
+    @pytest.mark.asyncio
+    async def test_open_app_emits_interrupt(self) -> None:
+        result = await _run_until_interrupt("öffne Safari", "comp-open")
+        value = result.get("__interrupt__")[0].value
+        assert value["type"] == "computer"
+        assert value["action"] == "open_app"
+        assert "Safari" in value["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_confirmed_executes(self) -> None:
+        from agent.agents.computer import computer_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        with (
+            patch("agent.agents.computer.get_llm", return_value=mock_llm),
+            patch("agent.agents.computer.computer_agent_execute", return_value="Geklickt auf (100, 200).") as mock_exec,
+        ):
+            app = _build_single_node_graph(computer_agent, AgentState)
+            config = {"configurable": {"thread_id": "comp-confirmed"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="klick auf 100, 200")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(
+                Command(
+                    resume={
+                        "confirmed": True,
+                        "rate_limit_ok": True,
+                        "action": "click",
+                        "x": 100,
+                        "y": 200,
+                        "text": "",
+                    }
+                ),
+                config,
+            )
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "click" and args[1] == 100 and args[2] == 200
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "Geklickt" in ai_msgs[-1].content
+
+    @pytest.mark.asyncio
+    async def test_resume_rejected_returns_abbruch(self) -> None:
+        from agent.agents.computer import computer_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        with (
+            patch("agent.agents.computer.get_llm", return_value=mock_llm),
+            patch("agent.agents.computer.computer_agent_execute") as mock_exec,
+        ):
+            app = _build_single_node_graph(computer_agent, AgentState)
+            config = {"configurable": {"thread_id": "comp-rejected"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="klick auf 5, 5")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(Command(resume={"confirmed": False}), config)
+
+        mock_exec.assert_not_called()
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "abgebrochen" in ai_msgs[-1].content.lower()
+
+    @pytest.mark.asyncio
+    async def test_resume_rate_limited_blocks(self) -> None:
+        from agent.agents.computer import computer_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        with (
+            patch("agent.agents.computer.get_llm", return_value=mock_llm),
+            patch("agent.agents.computer.computer_agent_execute") as mock_exec,
+        ):
+            app = _build_single_node_graph(computer_agent, AgentState)
+            config = {"configurable": {"thread_id": "comp-rl"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="klick auf 5, 5")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(
+                Command(
+                    resume={"confirmed": True, "rate_limit_ok": False, "action": "click", "x": 5, "y": 5, "text": ""}
+                ),
+                config,
+            )
+
+        mock_exec.assert_not_called()
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "rate limit" in ai_msgs[-1].content.lower()
+
+
+class TestBotHandleInterruptComputer:
+    @pytest.mark.asyncio
+    async def test_computer_confirmed_passes_fields(self) -> None:
+        import bot.bot as bot_mod
+
+        with (
+            patch("bot.bot.request_confirmation", AsyncMock(return_value=True)),
+            patch("bot.bot.check_action_rate_limit", return_value=True),
+        ):
+            decision = await bot_mod._handle_interrupt(
+                {
+                    "type": "computer",
+                    "action": "click",
+                    "x": 100,
+                    "y": 200,
+                    "text": "",
+                    "display": "click @ (100, 200)",
+                },
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision["confirmed"] is True
+        assert decision["rate_limit_ok"] is True
+        assert decision["action"] == "click"
+        assert decision["x"] == 100
+        assert decision["y"] == 200
+
+    @pytest.mark.asyncio
+    async def test_computer_rejected_returns_false(self) -> None:
+        import bot.bot as bot_mod
+
+        with patch("bot.bot.request_confirmation", AsyncMock(return_value=False)):
+            decision = await bot_mod._handle_interrupt(
+                {"type": "computer", "action": "click", "x": 1, "y": 1, "text": ""},
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision == {"confirmed": False}


### PR DESCRIPTION
Task 2/4 aus Meta-Issue #274 (HITL-Cluster).

## Änderung
Migriert `click`/`type`/`open_app` vom `__CONFIRM_COMPUTER__:`-Magic-String auf das `interrupt()`-Pattern. Screenshot-Pfad unverändert.

- **`computer.py`**: drei Aktions-Zweige zu einem gemeinsamen `interrupt({"type": "computer", ...})`-Pfad konsolidiert. Rate-Limit (`destructive`) + Werte post-resume aus `decision` (Source of Truth gegen LLM-/Parser-Drift bei Node-Re-Execution).
- **`bot.py`**: `_handle_interrupt()`-Branch für `computer` (inkl. Rate-Limit); `_handle_confirm_computer` + `_RESPONSE_DISPATCH`-Eintrag + verwaister `computer_agent_execute`-Import entfernt.
- **Tests**: `test_ph224_hitl_computer.py` – Interrupt-Emission je Aktion, confirmed (ruft `computer_agent_execute`), rejected, rate-limited, `_handle_interrupt`-Bridge.

## Bewusst belassen
- `Proto.CONFIRM_COMPUTER` + `chat_agent`-History-Cleanup → finaler Cleanup nach allen vier Migrationen.

## Test
Volle Suite grün (1837 passed).

Teil von #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)