### PR TITLE
refactor: HITL via interrupt() für whatsapp_agent (#274)

### DIFF
--- a/agent/agents/whatsapp_agent.py
+++ b/agent/agents/whatsapp_agent.py
@@ -8,10 +8,10 @@ import logging
 import re
 
 from langchain_core.messages import SystemMessage, AIMessage, HumanMessage
+from langgraph.types import interrupt
 from agent.state import AgentState
 from agent.audit import log_action
 from agent.llm import get_llm
-from agent.protocol import Proto
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ def _make_result(msg: str) -> AgentState:
 
 async def whatsapp_agent(state: AgentState) -> AgentState:
     """Phase 99: last_agent_result in allen Returns."""
-    from bot.whatsapp import find_contact, is_session_ready
+    from bot.whatsapp import find_contact, is_session_ready, send_whatsapp_message
 
     if not is_session_ready():
         return _make_result("WhatsApp nicht eingerichtet. Bitte /wa_setup ausführen.")
@@ -114,10 +114,42 @@ async def whatsapp_agent(state: AgentState) -> AgentState:
         status="pending",
     )
 
-    return {
-        "messages": [AIMessage(content=f"{Proto.CONFIRM_WHATSAPP}{whatsapp_name}::{message_text}")],
-        "next_agent": None,
-        "_confirm_display": f"WhatsApp an {contact_name}: {message_text}",
-        "last_agent_result": None,
-        "last_agent_name": "whatsapp_agent",
-    }
+    # Phase 225 (Issue #274): HITL via LangGraph interrupt() statt Magic-String-Return.
+    # Besonderheit: Versand (async I/O) passiert hier im Node NACH dem Resume –
+    # bot.py liefert nur Confirmation + Rate-Limit. Defensive: Werte aus decision.
+    display = f"WhatsApp an {contact_name}: {message_text}"
+    decision = interrupt(
+        {"type": "whatsapp", "whatsapp_name": whatsapp_name, "message": message_text, "display": display}
+    )
+
+    if not isinstance(decision, dict) or not decision.get("confirmed"):
+        log_action(
+            "whatsapp_agent",
+            "send",
+            f"user rejected: {whatsapp_name}",
+            state.get("telegram_chat_id"),
+            status="rejected",
+        )
+        return _make_result("WhatsApp abgebrochen.")
+
+    if not decision.get("rate_limit_ok", True):
+        log_action(
+            "whatsapp_agent",
+            "send",
+            f"action-rate-limited: {whatsapp_name}",
+            state.get("telegram_chat_id"),
+            status="blocked",
+        )
+        return _make_result("Rate Limit: zu viele Aktionen – bitte kurz warten.")
+
+    c_name = decision.get("whatsapp_name", whatsapp_name)
+    c_message = decision.get("message", message_text)
+    success, detail = await send_whatsapp_message(c_name, c_message)
+    log_action(
+        "whatsapp_agent",
+        "send",
+        f"to={c_name} len={len(c_message)}",
+        state.get("telegram_chat_id"),
+        status="executed" if success else "error",
+    )
+    return _make_result(detail)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -56,7 +56,6 @@ from agent.agents.computer import _screenshot_to_telegram_bytes
 from agent.agents.clip_agent import clip_agent, clip_agent_write
 from agent.agents.vision_agent import analyze_image_direct
 from bot.whatsapp import (
-    send_whatsapp_message,
     is_session_ready,
     add_whatsapp_contact,
     remove_whatsapp_contact,
@@ -68,8 +67,6 @@ from bot.whatsapp import (
 )
 
 logger = logging.getLogger(__name__)
-
-_TTS_MAX_HITL_OUTPUT = 300
 
 # Phase 91: Task-Registry für Background-Tasks in cmd_clip.
 _background_tasks: set[asyncio.Task] = set()
@@ -321,6 +318,19 @@ async def _handle_interrupt(interrupt_value: dict, bot: Bot, chat_id: int) -> di
             "text": interrupt_value.get("text", ""),
         }
 
+    if action_type == "whatsapp":
+        display = interrupt_value.get("display", "WhatsApp senden")
+        confirmed = await request_confirmation(bot, chat_id, "whatsapp_agent", display)
+        if not confirmed:
+            return {"confirmed": False}
+        rate_limit_ok = check_action_rate_limit(chat_id, "destructive")
+        return {
+            "confirmed": True,
+            "rate_limit_ok": rate_limit_ok,
+            "whatsapp_name": interrupt_value.get("whatsapp_name", ""),
+            "message": interrupt_value.get("message", ""),
+        }
+
     if action_type == "create_event":
         display = interrupt_value.get("display", "Neuer Termin")
         confirmed = await request_confirmation(bot, chat_id, "calendar_agent", display)
@@ -443,35 +453,8 @@ async def _handle_screenshot(response_msg: str, bot: Bot, chat_id: int, **_) -> 
     # bei Follow-up-Fragen den Screenshot-Kontext kennt.
 
 
-async def _handle_confirm_whatsapp(response_msg: str, bot: Bot, chat_id: int, **_) -> None:
-    parts = response_msg[len(Proto.CONFIRM_WHATSAPP) :].split("::", 1)
-    whatsapp_name = parts[0] if len(parts) > 0 else ""
-    message_text = parts[1] if len(parts) > 1 else ""
-    confirmed = await request_confirmation(
-        bot, chat_id, "whatsapp_agent", f"WhatsApp an {whatsapp_name}:\n{message_text}"
-    )
-    if confirmed:
-        if not check_action_rate_limit(chat_id, "destructive"):
-            await bot.send_message(chat_id=chat_id, text="⚠️ Rate Limit: zu viele Aktionen – bitte kurz warten.")
-            log_action("whatsapp_agent", "send", f"action-rate-limited: {whatsapp_name}", chat_id, status="blocked")
-            return
-        success, detail = await send_whatsapp_message(whatsapp_name, message_text)
-        await bot.send_message(chat_id=chat_id, text=detail)
-        await _update_memory(chat_id, f"WhatsApp gesendet an {whatsapp_name}: {message_text}")
-        log_action(
-            "whatsapp_agent",
-            "send",
-            f"to={whatsapp_name} len={len(message_text)}",
-            chat_id,
-            status="executed" if success else "error",
-        )
-    else:
-        log_action("whatsapp_agent", "send", f"user rejected: {whatsapp_name}", chat_id, status="rejected")
-
-
 _RESPONSE_DISPATCH: list[tuple[str, Any]] = [
     (Proto.SCREENSHOT, _handle_screenshot),
-    (Proto.CONFIRM_WHATSAPP, _handle_confirm_whatsapp),
 ]
 
 

--- a/tests/test_ph225_hitl_whatsapp.py
+++ b/tests/test_ph225_hitl_whatsapp.py
@@ -1,0 +1,203 @@
+"""
+Phase 225 (Issue #274, ex #244): HITL via LangGraph interrupt() für whatsapp_agent.
+
+Verifiziert dass whatsapp_agent statt eines __CONFIRM_WHATSAPP__-Magic-Strings
+einen Pregel-Interrupt auslöst. Besonderheit: der Versand (async I/O via
+send_whatsapp_message) passiert im Node NACH dem Resume.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import Command
+
+
+def _llm_response(text: str) -> MagicMock:
+    mock = MagicMock()
+    mock.content = text
+    return mock
+
+
+def _build_single_node_graph(node_fn, state_type):
+    g = StateGraph(state_type)
+    g.add_node("agent", node_fn)
+    g.add_edge(START, "agent")
+    g.add_edge("agent", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+_PARSE_JSON = '{"contact": "Steffi", "message": "Komme 10 Minuten später"}'
+
+
+def _patch_whatsapp_env():
+    """Patcht die lazy-importierten bot.whatsapp-Funktionen im Node."""
+    return patch.multiple(
+        "bot.whatsapp",
+        is_session_ready=MagicMock(return_value=True),
+        find_contact=MagicMock(return_value={"whatsapp_name": "Steffi W."}),
+    )
+
+
+async def _run_to_interrupt(thread_id: str):
+    from agent.agents.whatsapp_agent import whatsapp_agent
+    from agent.state import AgentState
+
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_PARSE_JSON))
+    with patch("agent.agents.whatsapp_agent.get_llm", return_value=mock_llm), _patch_whatsapp_env():
+        app = _build_single_node_graph(whatsapp_agent, AgentState)
+        config = {"configurable": {"thread_id": thread_id}}
+        result = await app.ainvoke(
+            {"messages": [HumanMessage(content="schick steffi dass ich später komme")], "telegram_chat_id": 42},
+            config,
+        )
+    return result
+
+
+class TestWhatsappAgentInterrupt:
+    @pytest.mark.asyncio
+    async def test_emits_interrupt(self) -> None:
+        result = await _run_to_interrupt("wa-1")
+        interrupts = result.get("__interrupt__")
+        assert interrupts is not None and len(interrupts) == 1
+        value = interrupts[0].value
+        assert value["type"] == "whatsapp"
+        assert value["whatsapp_name"] == "Steffi W."
+        assert "10 Minuten" in value["message"]
+
+    @pytest.mark.asyncio
+    async def test_resume_confirmed_sends(self) -> None:
+        from agent.agents.whatsapp_agent import whatsapp_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_PARSE_JSON))
+        mock_send = AsyncMock(return_value=(True, "Nachricht an Steffi W. gesendet."))
+        with (
+            patch("agent.agents.whatsapp_agent.get_llm", return_value=mock_llm),
+            _patch_whatsapp_env(),
+            patch("bot.whatsapp.send_whatsapp_message", mock_send),
+        ):
+            app = _build_single_node_graph(whatsapp_agent, AgentState)
+            config = {"configurable": {"thread_id": "wa-confirmed"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="schick steffi")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(
+                Command(
+                    resume={
+                        "confirmed": True,
+                        "rate_limit_ok": True,
+                        "whatsapp_name": "Steffi W.",
+                        "message": "Komme 10 Minuten später",
+                    }
+                ),
+                config,
+            )
+
+        mock_send.assert_awaited_once()
+        args = mock_send.call_args[0]
+        assert args[0] == "Steffi W."
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "gesendet" in ai_msgs[-1].content.lower()
+
+    @pytest.mark.asyncio
+    async def test_resume_rejected_does_not_send(self) -> None:
+        from agent.agents.whatsapp_agent import whatsapp_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_PARSE_JSON))
+        mock_send = AsyncMock()
+        with (
+            patch("agent.agents.whatsapp_agent.get_llm", return_value=mock_llm),
+            _patch_whatsapp_env(),
+            patch("bot.whatsapp.send_whatsapp_message", mock_send),
+        ):
+            app = _build_single_node_graph(whatsapp_agent, AgentState)
+            config = {"configurable": {"thread_id": "wa-rejected"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="schick steffi")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(Command(resume={"confirmed": False}), config)
+
+        mock_send.assert_not_awaited()
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "abgebrochen" in ai_msgs[-1].content.lower()
+
+    @pytest.mark.asyncio
+    async def test_resume_rate_limited_does_not_send(self) -> None:
+        from agent.agents.whatsapp_agent import whatsapp_agent
+        from agent.state import AgentState
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=_llm_response(_PARSE_JSON))
+        mock_send = AsyncMock()
+        with (
+            patch("agent.agents.whatsapp_agent.get_llm", return_value=mock_llm),
+            _patch_whatsapp_env(),
+            patch("bot.whatsapp.send_whatsapp_message", mock_send),
+        ):
+            app = _build_single_node_graph(whatsapp_agent, AgentState)
+            config = {"configurable": {"thread_id": "wa-rl"}}
+            await app.ainvoke(
+                {"messages": [HumanMessage(content="schick steffi")], "telegram_chat_id": 42},
+                config,
+            )
+            final = await app.ainvoke(
+                Command(
+                    resume={
+                        "confirmed": True,
+                        "rate_limit_ok": False,
+                        "whatsapp_name": "Steffi W.",
+                        "message": "X",
+                    }
+                ),
+                config,
+            )
+
+        mock_send.assert_not_awaited()
+        ai_msgs = [m for m in final["messages"] if isinstance(m, AIMessage)]
+        assert ai_msgs and "rate limit" in ai_msgs[-1].content.lower()
+
+
+class TestBotHandleInterruptWhatsapp:
+    @pytest.mark.asyncio
+    async def test_whatsapp_confirmed_passes_fields(self) -> None:
+        import bot.bot as bot_mod
+
+        with (
+            patch("bot.bot.request_confirmation", AsyncMock(return_value=True)),
+            patch("bot.bot.check_action_rate_limit", return_value=True),
+        ):
+            decision = await bot_mod._handle_interrupt(
+                {
+                    "type": "whatsapp",
+                    "whatsapp_name": "Steffi W.",
+                    "message": "Hallo",
+                    "display": "WhatsApp an Steffi",
+                },
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision["confirmed"] is True
+        assert decision["rate_limit_ok"] is True
+        assert decision["whatsapp_name"] == "Steffi W."
+        assert decision["message"] == "Hallo"
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_rejected_returns_false(self) -> None:
+        import bot.bot as bot_mod
+
+        with patch("bot.bot.request_confirmation", AsyncMock(return_value=False)):
+            decision = await bot_mod._handle_interrupt(
+                {"type": "whatsapp", "whatsapp_name": "X", "message": "Y"},
+                bot=MagicMock(),
+                chat_id=42,
+            )
+        assert decision == {"confirmed": False}

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -429,6 +429,22 @@ def _state(text: str) -> dict:
     }
 
 
+async def _run_agent(text: str, thread_id: str) -> dict:
+    """Phase 225: whatsapp_agent nutzt interrupt() – braucht Runnable-Kontext.
+    Läuft den Agent über einen Single-Node-Graph bis zum Interrupt."""
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.graph import StateGraph, START, END
+    from agent.agents.whatsapp_agent import whatsapp_agent
+    from agent.state import AgentState
+
+    g = StateGraph(AgentState)
+    g.add_node("agent", whatsapp_agent)
+    g.add_edge(START, "agent")
+    g.add_edge("agent", END)
+    app = g.compile(checkpointer=MemorySaver())
+    return await app.ainvoke(_state(text), {"configurable": {"thread_id": thread_id}})
+
+
 _CONTACTS = [
     {"name": "Steffi", "whatsapp_name": "Steffi 🌞"},
     {"name": "Amalia", "whatsapp_name": "Amalia"},
@@ -464,9 +480,6 @@ class TestWhatsappAgent:
         assert "erlaubte kontakte" not in content.lower()
 
     async def test_valid_contact_returns_hitl(self):
-        from agent.agents.whatsapp_agent import whatsapp_agent
-        from agent.protocol import Proto
-
         llm_response = AIMessage(content='{"contact": "Steffi", "message": "Ich komme später"}')
         contact = {"name": "Steffi", "whatsapp_name": "Steffi 🌞"}
         with (
@@ -476,11 +489,11 @@ class TestWhatsappAgent:
             patch("agent.agents.whatsapp_agent.log_action"),
         ):
             mock_llm.return_value.ainvoke = AsyncMock(return_value=llm_response)
-            result = await whatsapp_agent(_state("Schick Steffi dass ich später komme"))
-        content = result["messages"][-1].content
-        assert content.startswith(Proto.CONFIRM_WHATSAPP)
-        assert "Steffi 🌞" in content
-        assert "Ich komme später" in content
+            result = await _run_agent("Schick Steffi dass ich später komme", "wa-valid")
+        value = result["__interrupt__"][0].value
+        assert value["type"] == "whatsapp"
+        assert value["whatsapp_name"] == "Steffi 🌞"
+        assert "Ich komme später" in value["message"]
 
     async def test_empty_contact_asks_user(self):
         from agent.agents.whatsapp_agent import whatsapp_agent
@@ -522,8 +535,6 @@ class TestWhatsappAgent:
         assert "anschreiben" in content.lower()
 
     async def test_whatsapp_name_with_emoji(self):
-        from agent.agents.whatsapp_agent import whatsapp_agent
-
         llm_response = AIMessage(content='{"contact": "Steffi", "message": "Test"}')
         contact = {"name": "Steffi", "whatsapp_name": "Steffi 🌞"}
         with (
@@ -533,13 +544,10 @@ class TestWhatsappAgent:
             patch("agent.agents.whatsapp_agent.log_action"),
         ):
             mock_llm.return_value.ainvoke = AsyncMock(return_value=llm_response)
-            result = await whatsapp_agent(_state("Schick Steffi Test"))
-        assert "Steffi 🌞" in result["messages"][-1].content
+            result = await _run_agent("Schick Steffi Test", "wa-emoji")
+        assert result["__interrupt__"][0].value["whatsapp_name"] == "Steffi 🌞"
 
     async def test_fabio_self_send(self):
-        from agent.agents.whatsapp_agent import whatsapp_agent
-        from agent.protocol import Proto
-
         llm_response = AIMessage(content='{"contact": "Fabio", "message": "Test 123"}')
         contact = {"name": "Fabio", "whatsapp_name": "Fabio Morena (du)"}
         with (
@@ -549,10 +557,10 @@ class TestWhatsappAgent:
             patch("agent.agents.whatsapp_agent.log_action"),
         ):
             mock_llm.return_value.ainvoke = AsyncMock(return_value=llm_response)
-            result = await whatsapp_agent(_state("Schick mir selbst Test 123"))
-        content = result["messages"][-1].content
-        assert content.startswith(Proto.CONFIRM_WHATSAPP)
-        assert "Fabio Morena (du)" in content
+            result = await _run_agent("Schick mir selbst Test 123", "wa-self")
+        value = result["__interrupt__"][0].value
+        assert value["type"] == "whatsapp"
+        assert value["whatsapp_name"] == "Fabio Morena (du)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Task 3/4 aus Meta-Issue #274 (HITL-Cluster).

## Änderung
Migriert WhatsApp-Send vom `__CONFIRM_WHATSAPP__:`-Magic-String auf `interrupt()`.

**Besonderheit (async I/O):** Der Versand via `send_whatsapp_message` passiert im Agent-Node **nach** dem Resume – nicht in `_handle_interrupt`. `bot.py` liefert nur Confirmation + Rate-Limit. So bleibt der async-Send pattern-konsistent zum terminal-Agent (Node läuft bei Resume neu).

- **`whatsapp_agent.py`**: `interrupt({"type": "whatsapp", ...})`; `send_whatsapp_message` wird nach Resume awaited; Werte post-resume aus `decision`.
- **`bot.py`**: `_handle_interrupt()`-Branch für `whatsapp`; `_handle_confirm_whatsapp` + letzter `_RESPONSE_DISPATCH`-Eintrag (außer SCREENSHOT) + verwaister `send_whatsapp_message`-Import + ungenutzte `_TTS_MAX_HITL_OUTPUT`-Konstante entfernt.
- **`test_whatsapp.py`**: 3 HITL-Tests auf Graph-/interrupt-Pattern umgestellt (prüfen jetzt den interrupt-value statt Magic-String).
- **Tests**: `test_ph225_hitl_whatsapp.py` – interrupt, confirmed-sendet (awaited `send_whatsapp_message`), rejected, rate-limited, bridge.

## Bewusst belassen
- `Proto.CONFIRM_WHATSAPP` + `chat_agent`-History-Cleanup → finaler Cleanup (Task 4 + Abschluss).

## Test
Volle Suite grün (1843 passed).

Teil von #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)