### PR TITLE
refactor: toten CONFIRM_*-Proto-Code entfernen (#274, finaler Cleanup)

### DIFF
--- a/agent/protocol.py
+++ b/agent/protocol.py
@@ -1,74 +1,20 @@
 """
 Zentrales Protokoll-Modul für FabBot.
 
-Phase 91 Fixes:
-- Proto.MEMORY_VISION_MARKER: Magic String "Bildbeschreibung" aus supervisor.py extrahiert.
-  Vorher hardcoded in _filter_hitl_messages() – bei Format-Änderung stille Regression.
-- Proto.is_any_confirm(): CONFIRM_VISION ergänzt (war vergessen).
-  Vorher: Vision-Confirmations wurden von is_any_confirm() nicht erkannt.
+Phase 226 (Issue #274): HITL läuft vollständig über LangGraph interrupt() –
+die CONFIRM_*-Magic-Strings und is_confirm_*/is_any_confirm wurden entfernt.
+Übrig bleiben SCREENSHOT (Screenshot-Dispatch) und MEMORY_VISION_MARKER.
 """
 
 
 class Proto:
-    # Prefixes für HITL-Bestätigungen
-    CONFIRM_TERMINAL = "__CONFIRM_TERMINAL__:"
-    CONFIRM_FILE_WRITE = "__CONFIRM_FILE_WRITE__:"
-    CONFIRM_CREATE_EVENT = "__CONFIRM_CREATE_EVENT__:"
-    CONFIRM_COMPUTER = "__CONFIRM_COMPUTER__:"
-    CONFIRM_WHATSAPP = "__CONFIRM_WHATSAPP__:"
-
-    # Screenshot-Antwort
+    # Screenshot-Antwort (einziger verbleibender Dispatch-Marker)
     SCREENSHOT = "__SCREENSHOT__:"
 
-    # Vision-Analyse Bestätigung
-    CONFIRM_VISION = "__CONFIRM_VISION__:"
-
-    # Vision-Ergebnis – intern, wird an chat_agent weitergeleitet
-    VISION_RESULT = "__VISION_RESULT__:"
-
     # Phase 91: Kennzeichnet Vision-Memory-Messages die im State sichtbar bleiben sollen.
-    # Vorher: "Bildbeschreibung" hardcoded in supervisor._filter_hitl_messages() –
-    # Format-Änderung hätte die Filterlogik still gebrochen.
-    # Jetzt: Single Source of Truth in protocol.py.
+    # Single Source of Truth in protocol.py (genutzt in supervisor._filter_hitl_messages()).
     MEMORY_VISION_MARKER = "Bildbeschreibung"
-
-    @staticmethod
-    def is_confirm_whatsapp(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_WHATSAPP)
-
-    @staticmethod
-    def is_confirm_terminal(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_TERMINAL)
-
-    @staticmethod
-    def is_confirm_file_write(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_FILE_WRITE)
-
-    @staticmethod
-    def is_confirm_create_event(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_CREATE_EVENT)
-
-    @staticmethod
-    def is_confirm_computer(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_COMPUTER)
 
     @staticmethod
     def is_screenshot(msg: str) -> bool:
         return msg.startswith(Proto.SCREENSHOT)
-
-    @staticmethod
-    def is_confirm_vision(msg: str) -> bool:
-        return msg.startswith(Proto.CONFIRM_VISION)
-
-    @staticmethod
-    def is_any_confirm(msg: str) -> bool:
-        return any(
-            [
-                Proto.is_confirm_terminal(msg),
-                Proto.is_confirm_file_write(msg),
-                Proto.is_confirm_create_event(msg),
-                Proto.is_confirm_computer(msg),
-                Proto.is_confirm_whatsapp(msg),
-                Proto.is_confirm_vision(msg),  # Phase 91: war vergessen
-            ]
-        )

--- a/tests/test_ph91_fixes.py
+++ b/tests/test_ph91_fixes.py
@@ -34,38 +34,6 @@ class TestProtocolFixes:
 
         assert Proto.MEMORY_VISION_MARKER == "Bildbeschreibung"
 
-    def test_is_any_confirm_includes_vision(self) -> None:
-        """is_any_confirm() erkennt CONFIRM_VISION."""
-        from agent.protocol import Proto
-
-        vision_msg = f"{Proto.CONFIRM_VISION}some data"
-        assert Proto.is_any_confirm(vision_msg) is True
-
-    def test_is_any_confirm_still_covers_all_others(self) -> None:
-        """is_any_confirm() deckt weiterhin alle anderen Confirm-Typen ab."""
-        from agent.protocol import Proto
-
-        assert Proto.is_any_confirm(f"{Proto.CONFIRM_TERMINAL}ls") is True
-        assert Proto.is_any_confirm(f"{Proto.CONFIRM_FILE_WRITE}/tmp/x::y") is True
-        assert Proto.is_any_confirm(f"{Proto.CONFIRM_CREATE_EVENT}Meeting::2026") is True
-        assert Proto.is_any_confirm(f"{Proto.CONFIRM_COMPUTER}click:0:0:") is True
-        assert Proto.is_any_confirm(f"{Proto.CONFIRM_WHATSAPP}Steffi::Hallo") is True
-
-    def test_is_any_confirm_false_for_non_confirm(self) -> None:
-        """is_any_confirm() gibt False für normale Nachrichten zurück."""
-        from agent.protocol import Proto
-
-        assert Proto.is_any_confirm("normale nachricht") is False
-        assert Proto.is_any_confirm("__SCREENSHOT__:data") is False
-        assert Proto.is_any_confirm("") is False
-
-    def test_is_confirm_vision_standalone(self) -> None:
-        """is_confirm_vision() funktioniert korrekt."""
-        from agent.protocol import Proto
-
-        assert Proto.is_confirm_vision(f"{Proto.CONFIRM_VISION}data") is True
-        assert Proto.is_confirm_vision("andere nachricht") is False
-
     def test_memory_vision_marker_used_in_supervisor(self) -> None:
         """supervisor._filter_hitl_messages nutzt Proto.MEMORY_VISION_MARKER."""
         import inspect

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -561,38 +561,3 @@ class TestWhatsappAgent:
         value = result["__interrupt__"][0].value
         assert value["type"] == "whatsapp"
         assert value["whatsapp_name"] == "Fabio Morena (du)"
-
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
-
-
-class TestProtoWhatsapp:
-    def test_confirm_whatsapp_prefix(self):
-        from agent.protocol import Proto
-
-        assert Proto.CONFIRM_WHATSAPP == "__CONFIRM_WHATSAPP__:"
-
-    def test_is_confirm_whatsapp_true(self):
-        from agent.protocol import Proto
-
-        assert Proto.is_confirm_whatsapp("__CONFIRM_WHATSAPP__:Steffi 🌞::Hallo") is True
-
-    def test_is_confirm_whatsapp_false(self):
-        from agent.protocol import Proto
-
-        assert Proto.is_confirm_whatsapp("__CONFIRM_TERMINAL__:ls") is False
-        assert Proto.is_confirm_whatsapp("") is False
-
-    def test_is_any_confirm_includes_whatsapp(self):
-        from agent.protocol import Proto
-
-        assert Proto.is_any_confirm("__CONFIRM_WHATSAPP__:x::y") is True
-
-    def test_is_any_confirm_still_covers_others(self):
-        from agent.protocol import Proto
-
-        assert Proto.is_any_confirm("__CONFIRM_TERMINAL__:ls") is True
-        assert Proto.is_any_confirm("__CONFIRM_FILE_WRITE__:/tmp/x::content") is True
-        assert Proto.is_any_confirm("__CONFIRM_COMPUTER__:click:0:0:") is True


### PR DESCRIPTION
Task 4/4 + finaler Cleanup aus Meta-Issue #274 (HITL-Cluster).

## Befund: vision braucht keine Migration
`vision_agent` ist nur ein Fallback-Node. Die Bildanalyse läuft direkt über `analyze_image_direct` beim Foto-Upload (`bot.py:863/921`) – **ohne HITL, ohne Marker**. `__CONFIRM_VISION__` und `__VISION_RESULT__` werden **nirgends mehr produziert** (verifiziert). Issue #245 basierte auf veraltetem Stand.

## Finaler Cleanup
Nach allen Migrationen (calendar/computer/whatsapp + Phase 212 terminal/file) ist die `CONFIRM_*`-Proto-Infrastruktur toter Code – im Produktivcode wird nur noch `Proto.SCREENSHOT` genutzt; `is_confirm_*`/`is_any_confirm` hatten nur noch Test-Konsumenten.

- **`protocol.py`**: alle `CONFIRM_*`-Konstanten + `VISION_RESULT` + `is_confirm_*`/`is_any_confirm` entfernt. **Behalten**: `SCREENSHOT` (+ `is_screenshot`), `MEMORY_VISION_MARKER` (aktiv in supervisor).
- **Tests**: obsolete Proto-Confirm-Tests aus `test_ph91_fixes.py` + `test_whatsapp.py` entfernt.

## Bewusst belassen
History-Cleanups in `chat_agent`/`terminal`/`session_summary` nutzen **rohe** Magic-Strings (kein Proto-Bezug) – defensiv für alte Checkpoint-States, daher unangetastet.

## Test
Volle Suite grün (1834 passed). `_RESPONSE_DISPATCH` enthält nur noch `SCREENSHOT`.

Schließt #274 ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)