### PR TITLE
fix: pip-audit – langsmith + pydantic-settings Sicherheits-Bumps

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -110,7 +110,7 @@ langgraph-prebuilt==1.0.8
     # via langgraph
 langgraph-sdk==0.3.11
     # via langgraph
-langsmith==0.8.3
+langsmith==0.8.18
     # via langchain-core
 llvmlite==0.46.0
     # via numba
@@ -167,7 +167,7 @@ pyasn1-modules==0.4.2
 pycparser==3.0
     # via cffi
 pydantic==2.12.5
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via fabbot (agent/config.py)
     # via
     #   anthropic

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ langgraph-checkpoint==4.0.1
 langgraph-checkpoint-sqlite==3.0.3
 langgraph-prebuilt==1.0.9
 langgraph-sdk==0.3.11
-langsmith==0.8.3
+langsmith==0.8.18
 license-expression==30.4.4
 librosa==0.11.0
 llvmlite==0.46.0
@@ -119,7 +119,7 @@ PyAutoGUI==0.9.54
 pybase64==1.4.3
 pycparser==3.0
 pydantic==2.12.5
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
 pydantic_core==2.41.5
 pyee==13.0.1
 PyGetWindow==0.0.9


### PR DESCRIPTION
## Problem

Der CI-`test`-Job (pip-audit) failt an zwei frischen CVEs in transitiven/Config-Deps – blockiert aktuell jeden Branch (u.a. PR #296).

## Fix

- `langsmith` 0.8.3 → **0.8.18** (GHSA-f4xh-w4cj-qxq8)
- `pydantic-settings` 2.13.1 → **2.14.2** (GHSA-4xgf-cpjx-pc3j)

In `requirements.txt` und `requirements-ci.txt`.

## Verifikation

- `pip-audit` (exakter CI-Befehl): No known vulnerabilities found
- `pip check`: keine Konflikte
- 1879 Tests grün, Imports mit neuen Versionen OK