### PR TITLE
fix: flaky test_ph145 heartbeat – Test-Isolation gegen echte activity.json

### DIFF
--- a/tests/test_ph145_heartbeat.py
+++ b/tests/test_ph145_heartbeat.py
@@ -204,6 +204,10 @@ class TestRunHeartbeat:
             patch("bot.heartbeat_scheduler.is_on_cooldown", return_value=False),
             patch("bot.heartbeat_scheduler.is_muted", return_value=False),
             patch("bot.heartbeat_scheduler.is_quiet_hours", return_value=False),
+            # is_focus_muted wird lokal in _run_heartbeat importiert und liest sonst
+            # die echte ~/.fabbot/activity.json → Test war flaky (HARD_MUTE bei
+            # veralteter Aktivität → früher Return, keine Nachricht). Quelle patchen.
+            patch("agent.proactive.focus_mode.is_focus_muted", return_value=False),
             patch("bot.heartbeat_scheduler.run_api_health_check", new_callable=AsyncMock),
             patch("bot.heartbeat_scheduler.get_pending_items", return_value=pending),
             patch("bot.heartbeat_scheduler.evaluate_time_triggers", return_value=[trigger]),


### PR DESCRIPTION
## Problem

`TestRunHeartbeat::test_sends_message_when_triggered` war flaky (mal grün, mal rot in CI). Ursache: `_run_heartbeat` importiert `is_focus_muted` **lokal** aus `agent.proactive.focus_mode`, das über `get_idle_seconds()` die **echte** `~/.fabbot/activity.json` des laufenden Bots liest.

- Frische Aktivität → NORMAL → Test grün
- Veraltete Aktivität (> `focus_hard_mute_min`, default 60 Min) → HARD_MUTE → `_run_heartbeat` kehrt früh zurück → `send_message` nie aufgerufen → **Test rot**

Der Test koppelte also an externen Laufzeit-Zustand statt isoliert zu sein.

## Fix

`agent.proactive.focus_mode.is_focus_muted` im Test auf `False` patchen – analog zu den bereits gemockten Gates `is_on_cooldown`/`is_muted`/`is_quiet_hours`. Patch zielt auf die **Quelle**, da der Import in `_run_heartbeat` lokal erfolgt (nicht Modul-Level in heartbeat_scheduler).

## Verifikation

- Failure deterministisch reproduziert: `FOCUS_HARD_MUTE_MIN=0 pytest …` → rot (vor Fix)
- Nach Fix: gleicher erzwungener HARD_MUTE-Zustand → grün
- Volle Suite: 1882 passed, 1 skipped, 0 failures

Reiner Test-Fix, keine Verhaltensänderung am Bot.